### PR TITLE
Set hostname to user configurable device name if possible

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/App.java
+++ b/android/src/main/java/com/tailscale/ipn/App.java
@@ -115,7 +115,8 @@ public class App extends Application {
 
 		if (!isEmpty(nameFromSystemBluetooth)) return nameFromSystemBluetooth;
 		if (!isEmpty(nameFromSecureBluetooth)) return nameFromSecureBluetooth;
-		return nameFromSystemDevice;
+		if (!isEmpty(nameFromSystemDevice)) return nameFromSystemDevice;
+		return null;
 	}
 
 	private static boolean isEmpty(String str) {

--- a/android/src/main/java/com/tailscale/ipn/App.java
+++ b/android/src/main/java/com/tailscale/ipn/App.java
@@ -86,7 +86,7 @@ public class App extends Application {
 
 	String getHostname() {
 		String userConfiguredDeviceName = getUserConfiguredDeviceName();
-		if (notEmpty(userConfiguredDeviceName)) return userConfiguredDeviceName;
+		if (!isEmpty(userConfiguredDeviceName)) return userConfiguredDeviceName;
 
 		return getModelName();
 	}
@@ -113,13 +113,13 @@ public class App extends Application {
 		Log.d("com.tailscale.ipn.App", "Device name from Secure Bluetooth: " + nameFromSecureBluetooth);
 		Log.d("com.tailscale.ipn.App", "Device name from System Device: " + nameFromSystemDevice);
 
-		if (notEmpty(nameFromSystemBluetooth)) return nameFromSystemBluetooth;
-		if (notEmpty(nameFromSecureBluetooth)) return nameFromSecureBluetooth;
+		if (!isEmpty(nameFromSystemBluetooth)) return nameFromSystemBluetooth;
+		if (!isEmpty(nameFromSecureBluetooth)) return nameFromSecureBluetooth;
 		return nameFromSystemDevice;
 	}
 
-	private static boolean notEmpty(String str) {
-		return !(str == null || str.length() == 0);
+	private static boolean isEmpty(String str) {
+		return str == null || str.length() == 0;
 	}
 
 	// Tracklifecycle adds a Peer fragment for tracking the Activity

--- a/android/src/main/java/com/tailscale/ipn/App.java
+++ b/android/src/main/java/com/tailscale/ipn/App.java
@@ -15,7 +15,6 @@ import android.content.SharedPreferences;
 import android.content.BroadcastReceiver;
 import android.provider.Settings;
 import android.net.ConnectivityManager;
-import android.util.Log;
 import android.view.View;
 import android.os.Build;
 
@@ -109,10 +108,6 @@ public class App extends Application {
 		String nameFromSystemBluetooth = Settings.System.getString(getContentResolver(), "bluetooth_name");
 		String nameFromSecureBluetooth = Settings.Secure.getString(getContentResolver(), "bluetooth_name");
 		String nameFromSystemDevice = Settings.Secure.getString(getContentResolver(), "device_name");
-
-		Log.d("com.tailscale.ipn.App", "Device name from System Bluetooth: " + nameFromSystemBluetooth);
-		Log.d("com.tailscale.ipn.App", "Device name from Secure Bluetooth: " + nameFromSecureBluetooth);
-		Log.d("com.tailscale.ipn.App", "Device name from System Device: " + nameFromSystemDevice);
 
 		if (!isEmpty(nameFromSystemBluetooth)) return nameFromSystemBluetooth;
 		if (!isEmpty(nameFromSecureBluetooth)) return nameFromSecureBluetooth;

--- a/android/src/main/java/com/tailscale/ipn/App.java
+++ b/android/src/main/java/com/tailscale/ipn/App.java
@@ -13,7 +13,9 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.BroadcastReceiver;
+import android.provider.Settings;
 import android.net.ConnectivityManager;
+import android.util.Log;
 import android.view.View;
 import android.os.Build;
 
@@ -83,6 +85,13 @@ public class App extends Application {
 	}
 
 	String getHostname() {
+		String userConfiguredDeviceName = getUserConfiguredDeviceName();
+		if (notEmpty(userConfiguredDeviceName)) return userConfiguredDeviceName;
+
+		return getModelName();
+	}
+
+	private String getModelName() {
 		String manu = Build.MANUFACTURER;
 		String model = Build.MODEL;
 		// Strip manufacturer from model.
@@ -92,6 +101,25 @@ public class App extends Application {
 			model = model.trim();
 		}
 		return manu + " " + model;
+	}
+
+	// get user defined nickname from Settings
+	private String getUserConfiguredDeviceName() {
+		String nameFromSystemBluetooth = Settings.System.getString(getContentResolver(), "bluetooth_name");
+		String nameFromSecureBluetooth = Settings.Secure.getString(getContentResolver(), "bluetooth_name");
+		String nameFromSystemDevice = Settings.Secure.getString(getContentResolver(), "device_name");
+
+		Log.d("com.tailscale.ipn.App", "Device name from System Bluetooth: " + nameFromSystemBluetooth);
+		Log.d("com.tailscale.ipn.App", "Device name from Secure Bluetooth: " + nameFromSecureBluetooth);
+		Log.d("com.tailscale.ipn.App", "Device name from System Device: " + nameFromSystemDevice);
+
+		if (notEmpty(nameFromSystemBluetooth)) return nameFromSystemBluetooth;
+		if (notEmpty(nameFromSecureBluetooth)) return nameFromSecureBluetooth;
+		return nameFromSystemDevice;
+	}
+
+	private static boolean notEmpty(String str) {
+		return !(str == null || str.length() == 0);
 	}
 
 	// Tracklifecycle adds a Peer fragment for tracking the Activity

--- a/android/src/main/java/com/tailscale/ipn/App.java
+++ b/android/src/main/java/com/tailscale/ipn/App.java
@@ -104,6 +104,7 @@ public class App extends Application {
 	}
 
 	// get user defined nickname from Settings
+	// returns null if not available
 	private String getUserConfiguredDeviceName() {
 		String nameFromSystemBluetooth = Settings.System.getString(getContentResolver(), "bluetooth_name");
 		String nameFromSecureBluetooth = Settings.Secure.getString(getContentResolver(), "bluetooth_name");


### PR DESCRIPTION
Attempt to fix https://github.com/tailscale/tailscale/issues/482

According to [1] it may not be possible to get the device nickname.
In this PR I tailscale tries to set hostname in the following order:
- Settings.System "bluetooth_name"
- Settings.Secure "bluetooth_name"
- Settings.System "device_name"
- Manufactor + Model

The first one available wins.
In my device, a Samsung S9, this is what I get from logcat:
```
06-19 19:27:00.517 28825 28937 D com.tailscale.ipn.App: Device name from System Bluetooth: null
06-19 19:27:00.517 28825 28937 D com.tailscale.ipn.App: Device name from Secure Bluetooth: destruction
06-19 19:27:00.517 28825 28937 D com.tailscale.ipn.App: Device name from System Device: null
```

I left the debug messages as I thought it would be useful, given how every device is a bit different.
Let me know what you think.


[1] https://medium.com/capital-one-tech/how-to-get-an-android-device-nickname-d5eab12f4ced