### PR TITLE
backend: use dns.NewNoopManager.

### DIFF
--- a/cmd/tailscale/backend.go
+++ b/cmd/tailscale/backend.go
@@ -89,7 +89,7 @@ func newBackend(dataDir string, jvm *jni.JVM, store *stateStore, settings settin
 		logID.UnmarshalText([]byte(storedLogID))
 	}
 	b.SetupLogs(dataDir, logID)
-	d, err := dns.NewOSConfigurator(logf, "")
+	d, err := dns.NewNoopManager()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Android updates its DNS config in updateTUN() when in response
to several different channels from the backend.

There is not an Android-specific NewOSConfigurator, we end
up pulling in the Linux NewOSConfigurator:
https://github.com/tailscale/tailscale/blob/main/net/dns/manager_linux.go

The Linux DNS manager expects to be able to write to /etc/resolv.conf,
which does not work on Android and causes errors in updating DNS config.

Instead, allocate dns.NewNoopManager to disable the DNS manager, and
rely on the updateTUN() code to handle DNS.

Fixes https://github.com/tailscale/tailscale/issues/1956

Signed-off-by: Denton Gentry <dgentry@tailscale.com>