### PR TITLE
backend: Send DNS config through CallbackRouter.

### DIFF
--- a/cmd/tailscale/backend.go
+++ b/cmd/tailscale/backend.go
@@ -87,16 +87,14 @@ func newBackend(dataDir string, jvm *jni.JVM, store *stateStore, settings settin
 		logID.UnmarshalText([]byte(storedLogID))
 	}
 	b.SetupLogs(dataDir, logID)
-	d, err := dns.NewNoopManager()
-	if err != nil {
-		return nil, err
+	cb := &router.CallbackRouter{
+		SetBoth:  b.setCfg,
+		SplitDNS: false, // TODO: https://github.com/tailscale/tailscale/issues/1695
 	}
 	engine, err := wgengine.NewUserspaceEngine(logf, wgengine.Config{
-		Tun: b.devices,
-		Router: &router.CallbackRouter{
-			SetBoth: b.setCfg,
-		},
-		DNS: d,
+		Tun:    b.devices,
+		Router: cb,
+		DNS:    cb,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("runBackend: NewUserspaceEngineAdvanced: %v", err)


### PR DESCRIPTION
Using NewNoopManager avoided the errors from trying to overwrite
/etc/resolv.conf, but still didn't fully work. Route DNS
config through the CallbackRouter.

Fixes https://github.com/tailscale/tailscale/issues/1956

Signed-off-by: Denton Gentry <dgentry@tailscale.com>