### PR TITLE
ui: show IPv6 address if there's no IPv4 address

### DIFF
--- a/cmd/tailscale/ui.go
+++ b/cmd/tailscale/ui.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"image"
 	"image/color"
-	"strings"
 	"time"
 
 	"gioui.org/f32"
@@ -25,6 +24,7 @@ import (
 	"gioui.org/widget"
 	"gioui.org/widget/material"
 	"golang.org/x/exp/shiny/materialdesign/icons"
+	"inet.af/netaddr"
 	"tailscale.com/ipn"
 	"tailscale.com/tailcfg"
 
@@ -839,15 +839,13 @@ func (ui *UI) layoutPeer(gtx layout.Context, sysIns system.Insets, p *UIPeer, us
 					})
 				}),
 				layout.Rigid(func(gtx C) D {
-					var addrs []string
+					var bestIP netaddr.IP // IP to show; first IPv4, or first IPv6 if no IPv4
 					for _, addr := range p.Peer.Addresses {
-						if addr.IP().Is6() {
-							// Don't surface IPv6 addresses.
-							continue
+						if ip := addr.IP(); bestIP.IsZero() || bestIP.Is6() && ip.Is4() {
+							bestIP = ip
 						}
-						addrs = append(addrs, addr.IP().String())
 					}
-					l := material.Body2(ui.theme, strings.Join(addrs, ","))
+					l := material.Body2(ui.theme, bestIP.String())
 					l.Color = rgb(0x434343)
 					return l.Layout(gtx)
 				}),


### PR DESCRIPTION
There are several situations where a peer may only have IPv6:
+ it was authorized using an ephemeral node key
  https://tailscale.com/kb/1111/ephemeral-nodes/
+ the Tailnet has IPv4 disabled
  https://twitter.com/bradfitz/status/1398380415124082690

So:
+ if a peer has an IPv4 address, display that.
+ if a peer does not have an IPv4 address, display IPv6.
+ If a peer does not have either IPv4 or IPv6 then leave
  the address blank and pretend nothing happened.

Signed-off-by: Denton Gentry <dgentry@tailscale.com>