### PR TITLE
android: bump version code

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ android {
     defaultConfig {
         minSdkVersion 22
         targetSdkVersion 29
-        versionCode 43
+        versionCode 44
         versionName "v1.10.0-405ea978f8b-g47b732aaab1"
     }
 	compileOptions {


### PR DESCRIPTION
On 6/24 I built a v43 and started to release it to production,
then decided to do an Internal release first. The Play Store
would not allow v43 to be used again so I built v44, released
it to Internal, and after testing promoted it to Production and
it went into Google's review process.

Crucially, I did not push the tags before going to bed.

On 6/25, not knowing any of this because I hadn't pushed the tags,
Elias built v43 and released it. The Play Store had apparently cleaned
up the state from my abandoned v43 by that point.

This commit increments the build number to v44 so we don't re-use it.
I'm not building an actual release, just incrementing the build
number and pointing to the same git commit. I'm hoping F-Droid will
therefore build exactly the same thing as it did for v43.

I promise to push the tags before going to bed next time.

Signed-off-by: Denton Gentry <dgentry@tailscale.com>