### PR TITLE
Makefile: download Tailscale's Go toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,9 @@ RUN echo y | $ANDROID_HOME/tools/bin/sdkmanager 'build-tools;28.0.3'
 
 # Get Go stable release
 WORKDIR $HOME
-ARG GO_VERSION=1.17rc1
+ARG GO_VERSION=1.16.5
 RUN curl -O https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz
-RUN echo "bfbd3881a01ca3826777b1c40f241acacd45b14730d373259cd673d74e15e534  go${GO_VERSION}.linux-amd64.tar.gz" | sha256sum -c
+RUN echo "b12c23023b68de22f74c0524f10b753e7b08b1504cb7e417eccebdd3fae49061  go${GO_VERSION}.linux-amd64.tar.gz" | sha256sum -c
 RUN tar -xzf go${GO_VERSION}.linux-amd64.tar.gz && mv go goroot
 ENV GOROOT $HOME/goroot
 ENV PATH $PATH:$GOROOT/bin:$HOME/bin:$ANDROID_HOME/platform-tools


### PR DESCRIPTION
Tailscale maintains a patched Go toolchain, pulling in
fixes early. Download the toolchain and use it to build.

Fixes https://github.com/tailscale/tailscale/issues/2450
in a better way.

Signed-off-by: Denton Gentry <dgentry@tailscale.com>