### PR TITLE
ui: more robust isConnected check.

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/App.java
+++ b/android/src/main/java/com/tailscale/ipn/App.java
@@ -26,6 +26,7 @@ import android.provider.Settings;
 import android.net.ConnectivityManager;
 import android.net.LinkProperties;
 import android.net.Network;
+import android.net.NetworkInfo;
 import android.net.NetworkRequest;
 import android.net.Uri;
 import android.net.VpnService;
@@ -98,14 +99,23 @@ public class App extends Application {
 	private void registerNetworkCallback() {
 		ConnectivityManager cMgr = (ConnectivityManager) this.getSystemService(Context.CONNECTIVITY_SERVICE);
 		cMgr.registerNetworkCallback(new NetworkRequest.Builder().build(), new ConnectivityManager.NetworkCallback() {
+			private void reportConnectivityChange() {
+				NetworkInfo active = cMgr.getActiveNetworkInfo();
+				// https://developer.android.com/training/monitoring-device-state/connectivity-status-type
+				boolean isConnected = active != null && active.isConnectedOrConnecting();
+				onConnectivityChanged(isConnected);
+			}
+
 			@Override
 			public void onLost(Network network) {
-				onConnectivityChanged(false);
+				super.onLost(network);
+				this.reportConnectivityChange();
 			}
 
 			@Override
 			public void onLinkPropertiesChanged(Network network, LinkProperties linkProperties) {
-				onConnectivityChanged(true);
+				super.onLinkPropertiesChanged(network, linkProperties);
+				this.reportConnectivityChange();
 			}
 		});
 	}

--- a/cmd/tailscale/main.go
+++ b/cmd/tailscale/main.go
@@ -471,6 +471,9 @@ func (a *App) runBackend() error {
 				}
 			}
 		case connected := <-onConnectivityChange:
+			if state.LostInternet != !connected {
+				log.Printf("LostInternet state change: %v -> %v", state.LostInternet, !connected)
+			}
 			state.LostInternet = !connected
 			if b != nil {
 				go b.LinkChange()


### PR DESCRIPTION
1. Follow
   https://developer.android.com/training/monitoring-device-state/connectivity-status-type
   to determine whether to report ourself as having connectivity or not.

   Tested by turning the Wifi & LTE off and on, seems to work well in
   the contrived test case.

2. Call superclass for onLost() and onLinkPropertiesChanged() handlers.
   Current Android versions have no code in the superclass of these two
   callbacks, but future proofiness.

3. Log when the UI report of LostInternet changes, so we can find it.

Fixes https://github.com/tailscale/tailscale/issues/3542

Signed-off-by: Denton Gentry <dgentry@tailscale.com>