### PR TITLE
Makefile: make toolchain sum not use absolute path.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,8 @@ VERSIONCODE_PLUSONE=$(shell expr $(VERSIONCODE) + 1)
 # When you update TOOLCHAINREV, also update TOOLCHAINWANT
 TOOLCHAINREV=7037d3ea514849c335b5c34d1f7e9380d17bd974
 TOOLCHAINDIR=${HOME}/.cache/tailscale-android-go-$(TOOLCHAINREV)
-TOOLCHAINSUM=$(shell find $(TOOLCHAINDIR) -type f -print0 | sort -z | xargs -0 sha1sum | sha1sum | cut -d" " -f1)
-TOOLCHAINWANT=1d3aded66a653a1d63c8a12952bd82327903a107
+TOOLCHAINSUM=$(shell cd $(TOOLCHAINDIR) && find . -type f -print0 | sort -z | xargs -0 sha1sum | sha1sum | cut -d" " -f1)
+TOOLCHAINWANT=925a8ea721ba7257c1ccc06112f2bd280868b997
 export PATH := $(TOOLCHAINDIR)/go/bin:$(PATH)
 
 all: $(APK)


### PR DESCRIPTION
This is intended as a quick fix of the immediate problem:
don't compute the checksum using absolute paths (i.e.
/home/dgentry), use relative paths.

In the future we may rationalize the versioning of the
toolchain to tie the Android toolchain to the one used
for building Linux/macOS/Windows/etc.

Fixes https://github.com/tailscale/tailscale/issues/3596

Signed-off-by: Denton Gentry <dgentry@tailscale.com>