### PR TITLE
go.mod: use Go toolchain rev from oss

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,12 @@ RUN echo y | $ANDROID_HOME/tools/bin/sdkmanager 'build-tools;28.0.3'
 ENV PATH $PATH:$HOME/bin:$ANDROID_HOME/platform-tools
 ENV ANDROID_SDK_ROOT /build/android-sdk
 
+# We need some version of Go new enough to support the "embed" package
+# to run "go run tailscale.com/cmd/printdep" to figure out which Tailscale Go
+# version we need later, but otherwise this toolchain isn't used:
+RUN curl -L https://go.dev/dl/go1.17.5.linux-amd64.tar.gz | tar -C /usr/local -zxv
+RUN ln -s /usr/local/go/bin/go /usr/bin
+
 RUN mkdir -p $HOME/tailscale-android
 WORKDIR $HOME/tailscale-android
 

--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,10 @@ VERSIONCODE=$(lastword $(shell grep versionCode android/build.gradle))
 VERSIONCODE_PLUSONE=$(shell expr $(VERSIONCODE) + 1)
 
 # When you update TOOLCHAINREV, also update TOOLCHAINWANT
-TOOLCHAINREV=7037d3ea514849c335b5c34d1f7e9380d17bd974
+TOOLCHAINREV=$(shell go run tailscale.com/cmd/printdep -go)
 TOOLCHAINDIR=${HOME}/.cache/tailscale-android-go-$(TOOLCHAINREV)
-TOOLCHAINSUM=$(shell cd $(TOOLCHAINDIR) && find . -type f -print0 | sort -z | xargs -0 sha1sum | sha1sum | cut -d" " -f1)
-TOOLCHAINWANT=925a8ea721ba7257c1ccc06112f2bd280868b997
+TOOLCHAINSUM=$(shell $(TOOLCHAINDIR)/go/bin/go version >/dev/null && echo "okay" || echo "bad")
+TOOLCHAINWANT=okay
 export PATH := $(TOOLCHAINDIR)/go/bin:$(PATH)
 
 all: $(APK)

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	golang.org/x/sys v0.0.0-20211205182925-97ca703d548d
 	golang.zx2c4.com/wireguard v0.0.0-20211116201604-de7c702ace45
 	inet.af/netaddr v0.0.0-20211027220019-c74959edd3b6
-	tailscale.com v1.1.1-0.20211211044717-cced414c7dd5
+	tailscale.com v1.1.1-0.20220103195654-dd45bba76b3a
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -701,3 +701,5 @@ tailscale.com v1.1.1-0.20211209004911-878a20df29fa h1:1Xo4A3TVgX243zuXzGoDnWtY88
 tailscale.com v1.1.1-0.20211209004911-878a20df29fa/go.mod h1:tUfoeG+nxHVB8mSKTdDVQeqCT1f7lwH8zkKPMgJGp7g=
 tailscale.com v1.1.1-0.20211211044717-cced414c7dd5 h1:tbL264fajLkzbYtsHiKJbkccZRPuHzZ5cYaE8CNc0y4=
 tailscale.com v1.1.1-0.20211211044717-cced414c7dd5/go.mod h1:kjVy3ji2OH5lZhPLIIRacoY3CN4Bo3Yyb2mtoM8nfJ4=
+tailscale.com v1.1.1-0.20220103195654-dd45bba76b3a h1:f1Ixr2b9pnSeVLRt1caMxd4rJVudGr60M1ykSTQRZBY=
+tailscale.com v1.1.1-0.20220103195654-dd45bba76b3a/go.mod h1:kjVy3ji2OH5lZhPLIIRacoY3CN4Bo3Yyb2mtoM8nfJ4=


### PR DESCRIPTION
And don't sha1-sum the Go toolchain cache.
Just see if its go binary works.

Updates tailscale/corp#3385
Updates tailscale/tailscale#3596