### PR TITLE
Makefile: make toolchain bootstrap work on darwin and arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,7 @@ TAILSCALE_COMMIT=$(shell echo $(TAILSCALE_VERSION) | cut -d - -f 2 | cut -d t -f
 VERSIONCODE=$(lastword $(shell grep versionCode android/build.gradle))
 VERSIONCODE_PLUSONE=$(shell expr $(VERSIONCODE) + 1)
 
-# When you update TOOLCHAINREV, also update TOOLCHAINWANT
-TOOLCHAINREV=$(shell go run tailscale.com/cmd/printdep -go)
+TOOLCHAINREV=$(shell go run tailscale.com/cmd/printdep --go)
 TOOLCHAINDIR=${HOME}/.cache/tailscale-android-go-$(TOOLCHAINREV)
 TOOLCHAINSUM=$(shell $(TOOLCHAINDIR)/go/bin/go version >/dev/null && echo "okay" || echo "bad")
 TOOLCHAINWANT=okay
@@ -42,11 +41,8 @@ ifneq ($(TOOLCHAINWANT),$(TOOLCHAINSUM))
 	@echo want: $(TOOLCHAINWANT)
 	@echo got: $(TOOLCHAINSUM)
 	rm -rf ${HOME}/.cache/tailscale-android-go-*
-	$(eval tmpfile=$(shell mktemp --suffix=.tgz))
-	wget https://github.com/tailscale/go/releases/download/build-$(TOOLCHAINREV)/linux.tar.gz -O "$(tmpfile)"
 	mkdir -p $(TOOLCHAINDIR)
-	tar xzf $(tmpfile) -C $(TOOLCHAINDIR)
-	rm $(tmpfile)
+	curl --silent -L $(shell go run tailscale.com/cmd/printdep --go-url) | tar -C $(TOOLCHAINDIR) -zx
 endif
 
 $(DEBUG_APK): toolchain

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	golang.org/x/sys v0.0.0-20211205182925-97ca703d548d
 	golang.zx2c4.com/wireguard v0.0.0-20211116201604-de7c702ace45
 	inet.af/netaddr v0.0.0-20211027220019-c74959edd3b6
-	tailscale.com v1.1.1-0.20220103195654-dd45bba76b3a
+	tailscale.com v1.1.1-0.20220106164417-64c2657448c9
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -703,3 +703,5 @@ tailscale.com v1.1.1-0.20211211044717-cced414c7dd5 h1:tbL264fajLkzbYtsHiKJbkccZR
 tailscale.com v1.1.1-0.20211211044717-cced414c7dd5/go.mod h1:kjVy3ji2OH5lZhPLIIRacoY3CN4Bo3Yyb2mtoM8nfJ4=
 tailscale.com v1.1.1-0.20220103195654-dd45bba76b3a h1:f1Ixr2b9pnSeVLRt1caMxd4rJVudGr60M1ykSTQRZBY=
 tailscale.com v1.1.1-0.20220103195654-dd45bba76b3a/go.mod h1:kjVy3ji2OH5lZhPLIIRacoY3CN4Bo3Yyb2mtoM8nfJ4=
+tailscale.com v1.1.1-0.20220106164417-64c2657448c9 h1:LFkTqkAfdB+FzWS0KmOwv2Y5ba0Kbbc3IQfHi6G09fA=
+tailscale.com v1.1.1-0.20220106164417-64c2657448c9/go.mod h1:kjVy3ji2OH5lZhPLIIRacoY3CN4Bo3Yyb2mtoM8nfJ4=


### PR DESCRIPTION
It only worked on linux/amd64 before, but we support
{linux,darwin}/{amd64,arm64} for development elsewhere.

Fixes tailscale/tailscale#3669
