### PR TITLE
Makefile: clear GOROOT, add rundebug target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ TOOLCHAINDIR=${HOME}/.cache/tailscale-android-go-$(TOOLCHAINREV)
 TOOLCHAINSUM=$(shell $(TOOLCHAINDIR)/go/bin/go version >/dev/null && echo "okay" || echo "bad")
 TOOLCHAINWANT=okay
 export PATH := $(TOOLCHAINDIR)/go/bin:$(PATH)
+export GOROOT := # Unset
 
 all: $(APK)
 
@@ -50,6 +51,10 @@ $(DEBUG_APK): toolchain
 	go run gioui.org/cmd/gogio -buildmode archive -target android -appid $(APPID) -o $(AAR) github.com/tailscale/tailscale-android/cmd/tailscale
 	(cd android && ./gradlew assemblePlayDebug)
 	mv android/build/outputs/apk/play/debug/android-play-debug.apk $@
+
+rundebug: $(DEBUG_APK)
+	adb install -r $(DEBUG_APK)
+	adb shell am start -n com.tailscale.ipn/com.tailscale.ipn.IPNActivity
 
 # tailscale-fdroid.apk builds a non-Google Play SDK, without the Google bits.
 # This is effectively what the F-Droid build definition produces.


### PR DESCRIPTION
Nowadays basically nobody should set GOROOT. I still do for various
reasons, but that broke this build which then ran our custom toolchain
with a mismatched GOROOT. Clear GOROOT so the default GOROOT is used
(which is the path that matches the Go toolchain in use)

Also, add a "rundebug" target to control adb (phone or emulator)