### PR TITLE
android: make apk android tv compatible

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -10,6 +10,10 @@
 	<!-- Disable input emulation on ChromeOS -->
 	<uses-feature android:name="android.hardware.type.pc" android:required="false"/>
 
+	<!-- Signal support for Android TV -->
+	<uses-feature android:name="android.software.leanback" android:required="false" />
+	<uses-feature android:name="android.hardware.touchscreen" android:required="false" />
+
 	<application android:label="Tailscale" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round"
 		android:name=".App" android:allowBackup="false">
 		<activity android:name="IPNActivity"
@@ -21,6 +25,7 @@
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />
 				<category android:name="android.intent.category.LAUNCHER" />
+				<category android:name="android.intent.category.LEANBACK_LAUNCHER" />
 			</intent-filter>
 			<intent-filter>
 				<action android:name="android.service.quicksettings.action.QS_TILE_PREFERENCES" />


### PR DESCRIPTION
These bits signal to Android TV OS that the apk is compatible with "leanback", so the apk can be more easily installed and launched on Android TV (and FireTV) devices.

This is also a pre-requisite to submitting the apk to the Play Store for Android TV.

See https://developer.android.com/training/tv/start/start#tv-activity

cc https://github.com/tailscale/tailscale/issues/1611