### PR TITLE
Add ability to choose a custom coordination server

### DIFF
--- a/cmd/tailscale/backend.go
+++ b/cmd/tailscale/backend.go
@@ -56,8 +56,9 @@ type settingsFunc func(*router.Config, *dns.OSConfig) error
 const defaultMTU = 1280 // minimalMTU from wgengine/userspace.go
 
 const (
-	logPrefKey         = "privatelogid"
-	loginMethodPrefKey = "loginmethod"
+	logPrefKey               = "privatelogid"
+	loginMethodPrefKey       = "loginmethod"
+	customLoginServerPrefKey = "customloginserver"
 )
 
 const (


### PR DESCRIPTION
This allows users to set a custom coordination/login/control server via a 3-dots menu on the login view.

This is sub-optimal in at least three ways, but I'm already out of my depth.
- The app restart is gross and shouldn't be necessary, but ipnlocal can't update ControlURL after Start() and I couldn't find another clean way to trigger ipnlocal.Start() again. I don't know golang, so don't dare go deeper.
- It should be clear on the login view (and maybe logged-in view) that a custom server is configured, maybe with an :x:
- It should be more obvious how to reset to default (erase the contents of the field and save)

<details><summary>Screenshots</summary>

![Screenshot of the normal login page, with a small three-dot menu button at the top right](https://user-images.githubusercontent.com/1053010/181613634-65b61700-db5c-4847-8ea3-02944277d4c3.png)
![Screenshot of the menu open, with a header, "Advanced settings", and one item, "Use login server"](https://user-images.githubusercontent.com/1053010/181613645-3ccda773-1e61-462f-ac6c-d4a615e10ace.png)
![Screenshot of the login server change page, showing three elements: a textbox with the placeholder "https://controlplane.tailscale.com", a "Save and restart" button, and a "Cancel" button](https://user-images.githubusercontent.com/1053010/181613651-26fea401-07e9-49de-8436-806148bfea5f.png)
</details>

Related:
https://twitter.com/dave_universetf/status/1415046381996167170
https://github.com/juanfont/headscale/issues/58
https://github.com/juanfont/headscale/issues/146