### PR TITLE
DnsConfig: don't use signed bytes when printing.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ endif
 $(DEBUG_APK): toolchain
 	mkdir -p android/libs
 	go run gioui.org/cmd/gogio -buildmode archive -target android -appid $(APPID) -tags novulkan -o $(AAR) github.com/tailscale/tailscale-android/cmd/tailscale
-	(cd android && ./gradlew assemblePlayDebug)
+	(cd android && ./gradlew test assemblePlayDebug)
 	mv android/build/outputs/apk/play/debug/android-play-debug.apk $@
 
 rundebug: $(DEBUG_APK)
@@ -66,7 +66,7 @@ rundebug: $(DEBUG_APK)
 tailscale-fdroid.apk: toolchain
 	mkdir -p android/libs
 	go run gioui.org/cmd/gogio -buildmode archive -target android -appid $(APPID) -tags novulkan -o $(AAR) github.com/tailscale/tailscale-android/cmd/tailscale
-	(cd android && ./gradlew assembleFdroidDebug)
+	(cd android && ./gradlew test assembleFdroidDebug)
 	mv android/build/outputs/apk/fdroid/debug/android-fdroid-debug.apk $@
 
 # This target is also used by the F-Droid builder.
@@ -76,7 +76,7 @@ release_aar:
 	go run gioui.org/cmd/gogio -ldflags "-X tailscale.com/version.Long=$(VERSIONNAME) -X tailscale.com/version.Short=$(VERSIONNAME_SHORT) -X tailscale.com/version.GitCommit=$(TAILSCALE_COMMIT) -X tailscale.com/version.ExtraGitCommit=$(OUR_VERSION)" -buildmode archive -target android -appid $(APPID) -tags novulkan -o $(AAR) github.com/tailscale/tailscale-android/cmd/tailscale
 
 $(RELEASE_AAB): release_aar
-	(cd android && ./gradlew bundlePlayRelease)
+	(cd android && ./gradlew test bundlePlayRelease)
 	mv ./android/build/outputs/bundle/playRelease/android-play-release.aab $@
 
 release: $(RELEASE_AAB)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,6 +50,7 @@ dependencies {
 	implementation "androidx.browser:browser:1.2.0"
 	implementation "androidx.security:security-crypto:1.1.0-alpha03"
 	implementation ':ipn@aar'
+	testCompile "junit:junit:4.12"
 
 	// Non-free dependencies.
 	playImplementation 'com.google.android.gms:play-services-auth:18.0.0'

--- a/android/src/main/java/com/tailscale/ipn/DnsConfig.java
+++ b/android/src/main/java/com/tailscale/ipn/DnsConfig.java
@@ -229,7 +229,7 @@ public class DnsConfig {
 	}
 
 
-	String intToInetString(int hostAddress) {
+	public String intToInetString(int hostAddress) {
 		return String.format(java.util.Locale.ROOT, "%d.%d.%d.%d",
 			(0xff & hostAddress),
 			(0xff & (hostAddress >> 8)),

--- a/android/src/main/java/com/tailscale/ipn/DnsConfig.java
+++ b/android/src/main/java/com/tailscale/ipn/DnsConfig.java
@@ -231,10 +231,10 @@ public class DnsConfig {
 
 	String intToInetString(int hostAddress) {
 		return String.format(java.util.Locale.ROOT, "%d.%d.%d.%d",
-			(byte)(0xff & hostAddress),
-			(byte)(0xff & (hostAddress >> 8)),
-			(byte)(0xff & (hostAddress >> 16)),
-			(byte)(0xff & (hostAddress >> 24)));
+			(0xff & hostAddress),
+			(0xff & (hostAddress >> 8)),
+			(0xff & (hostAddress >> 16)),
+			(0xff & (hostAddress >> 24)));
 	}
 
 	// getDnsServersFromNetworkInfo retrieves DNS servers using ConnectivityManager

--- a/android/src/test/java/com/tailscale/ipn/DnsConfigTest.java
+++ b/android/src/test/java/com/tailscale/ipn/DnsConfigTest.java
@@ -1,0 +1,21 @@
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import com.tailscale.ipn.DnsConfig;
+
+public class DnsConfigTest {
+	DnsConfig dns;
+
+	@Before
+	public void setup() {
+		dns = new DnsConfig(null);
+	}
+
+	@Test
+	public void dnsConfig_intToInetStringTest() {
+		assertEquals(dns.intToInetString(0x0101a8c0), "192.168.1.1");
+		assertEquals(dns.intToInetString(0x04030201), "1.2.3.4");
+		assertEquals(dns.intToInetString(0), "0.0.0.0");
+	}
+}


### PR DESCRIPTION
Two commits:

--------

intToInetString(0x0101a8c0) returns "-64.-88.1.1" because Java
integers are always signed. There is not a %u format specifier.

Though the quads of an IP address literally are bytes, they can
be left as an int to pass to String.format. This allows room for
sign bits, so intToInetString(0x0101a8c0) returns "192.168.1.1"

--------

adds JUnit dependencies and basic gradle support to run unit tests,
and a test for DnsConfig.intToInetString().

--------

Signed-off-by: Denton Gentry <dgentry@tailscale.com>