### PR TITLE
go.mod: update from OSS.

### DIFF
--- a/cmd/tailscale/main.go
+++ b/cmd/tailscale/main.go
@@ -16,6 +16,7 @@ import (
 	"mime"
 	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -628,7 +629,7 @@ func (s *BackendState) updateExitNodes() {
 	for _, p := range peers {
 		canRoute := false
 		for _, r := range p.AllowedIPs {
-			if r == netaddr.MustParseIPPrefix("0.0.0.0/0") || r == netaddr.MustParseIPPrefix("::/0") {
+			if r == netip.MustParsePrefix("0.0.0.0/0") || r == netip.MustParsePrefix("::/0") {
 				canRoute = true
 				break
 			}
@@ -1028,7 +1029,7 @@ func (a *App) updateState(act jni.Object, state *clientState) {
 			name := strings.ToLower(p.Name)
 			var addr string
 			if len(p.Addresses) > 0 {
-				addr = p.Addresses[0].IP().String()
+				addr = p.Addresses[0].Addr().String()
 			}
 			if !strings.Contains(host, q) && !strings.Contains(name, q) && !strings.Contains(addr, q) {
 				continue

--- a/cmd/tailscale/ui.go
+++ b/cmd/tailscale/ui.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"image"
 	"image/color"
+	"net/netip"
 	"time"
 
 	"gioui.org/f32"
@@ -26,7 +27,6 @@ import (
 	"gioui.org/widget/material"
 	qrcode "github.com/skip2/go-qrcode"
 	"golang.org/x/exp/shiny/materialdesign/icons"
-	"inet.af/netaddr"
 	"tailscale.com/client/tailscale/apitype"
 	"tailscale.com/ipn"
 	"tailscale.com/tailcfg"
@@ -310,7 +310,7 @@ func (ui *UI) layout(gtx layout.Context, sysIns system.Insets, state *clientStat
 		expiry = netmap.Expiry
 		localName = netmap.SelfNode.DisplayName(false)
 		if addrs := netmap.Addresses; len(addrs) > 0 {
-			localAddr = addrs[0].IP().String()
+			localAddr = addrs[0].Addr().String()
 		}
 	}
 	if p := state.backend.Prefs; p != nil {
@@ -476,7 +476,7 @@ func (ui *UI) layout(gtx layout.Context, sysIns system.Insets, state *clientStat
 					clk := &ui.peers[pidx]
 					if clk.Clicked() {
 						if addrs := p.Peer.Addresses; len(addrs) > 0 {
-							a := addrs[0].IP().String()
+							a := addrs[0].Addr().String()
 							events = append(events, CopyEvent{Text: a})
 							ui.showCopied(gtx, a)
 						}
@@ -1133,9 +1133,9 @@ func (ui *UI) layoutPeer(gtx layout.Context, sysIns system.Insets, p *UIPeer, us
 					})
 				}),
 				layout.Rigid(func(gtx C) D {
-					var bestIP netaddr.IP // IP to show; first IPv4, or first IPv6 if no IPv4
+					var bestIP netip.Addr // IP to show; first IPv4, or first IPv6 if no IPv4
 					for _, addr := range p.Peer.Addresses {
-						if ip := addr.IP(); bestIP.IsZero() || bestIP.Is6() && ip.Is4() {
+						if ip := addr.Addr(); bestIP.IsUnspecified() || bestIP.Is6() && ip.Is4() {
 							bestIP = ip
 						}
 					}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d
 	golang.zx2c4.com/wireguard v0.0.0-20220703234212-c31a7b1ab478
 	inet.af/netaddr v0.0.0-20220617031823-097006376321
-	tailscale.com v1.1.1-0.20220718172352-3c892d106c2e
+	tailscale.com v1.1.1-0.20220726050820-dd3e91b6785e
 )
 
 require (
@@ -53,6 +53,7 @@ require (
 	github.com/vishvananda/netns v0.0.0-20211101163701-50045581ed74 // indirect
 	go4.org/intern v0.0.0-20211027215823-ae77deb06f29 // indirect
 	go4.org/mem v0.0.0-20210711025021-927187094b94 // indirect
+	go4.org/netipx v0.0.0-20220725152314-7e7bdc8411bf // indirect
 	go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760 // indirect
 	golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f // indirect
 	golang.org/x/image v0.0.0-20210628002857-a66eb6448b8d // indirect
@@ -66,6 +67,6 @@ require (
 	golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f // indirect
 	golang.zx2c4.com/wintun v0.0.0-20211104114900-415007cec224 // indirect
 	golang.zx2c4.com/wireguard/windows v0.4.10 // indirect
-	gvisor.dev/gvisor v0.0.0-20220407223209-21871174d445 // indirect
+	gvisor.dev/gvisor v0.0.0-20220721202624-0b2c11c2773c // indirect
 	nhooyr.io/websocket v1.8.7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -492,6 +492,8 @@ go4.org/intern v0.0.0-20211027215823-ae77deb06f29 h1:UXLjNohABv4S58tHmeuIZDO6e3m
 go4.org/intern v0.0.0-20211027215823-ae77deb06f29/go.mod h1:cS2ma+47FKrLPdXFpr7CuxiTW3eyJbWew4qx0qtQWDA=
 go4.org/mem v0.0.0-20210711025021-927187094b94 h1:OAAkygi2Js191AJP1Ds42MhJRgeofeKGjuoUqNp1QC4=
 go4.org/mem v0.0.0-20210711025021-927187094b94/go.mod h1:reUoABIJ9ikfM5sgtSF3Wushcza7+WeD01VB9Lirh3g=
+go4.org/netipx v0.0.0-20220725152314-7e7bdc8411bf h1:IdwJUzqoIo5lkr2EOyKoe5qipUaEjbOKKY5+fzPBZ3A=
+go4.org/netipx v0.0.0-20220725152314-7e7bdc8411bf/go.mod h1:+QXzaoURFd0rGDIjDNpyIkv+F9R7EmeKorvlKRnhqgA=
 go4.org/unsafe/assume-no-moving-gc v0.0.0-20211027215541-db492cf91b37 h1:Tx9kY6yUkLge/pFG7IEMwDZy6CS2ajFc9TvQdPCW0uA=
 go4.org/unsafe/assume-no-moving-gc v0.0.0-20211027215541-db492cf91b37/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
 go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760 h1:FyBZqvoA/jbNzuAWLQE2kG820zMAkcilx6BMjGbL/E4=
@@ -773,6 +775,8 @@ gvisor.dev/gvisor v0.0.0-20220318082524-536b85ae1a6a h1:sQAuNyyy59GRxS8npo8nyOr5
 gvisor.dev/gvisor v0.0.0-20220318082524-536b85ae1a6a/go.mod h1:tWwEcFvJavs154OdjFCw78axNrsDlz4Zh8jvPqwcpGI=
 gvisor.dev/gvisor v0.0.0-20220407223209-21871174d445 h1:pLNQCtMzh4O6rdhoUeWHuutt4yMft+B9Cgw/bezWchE=
 gvisor.dev/gvisor v0.0.0-20220407223209-21871174d445/go.mod h1:tWwEcFvJavs154OdjFCw78axNrsDlz4Zh8jvPqwcpGI=
+gvisor.dev/gvisor v0.0.0-20220721202624-0b2c11c2773c h1:frrINYSQqhraHqy23/dWqdNt7mRlsGJJBwGHvI3Q+/c=
+gvisor.dev/gvisor v0.0.0-20220721202624-0b2c11c2773c/go.mod h1:TIvkJD0sxe8pIob3p6T8IzxXunlp6yfgktvTNp+DGNM=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
@@ -822,3 +826,5 @@ tailscale.com v1.1.1-0.20220712041646-755396d6fe77 h1:1YQCCgvywvVuD3A1hzc4L9bYMJ
 tailscale.com v1.1.1-0.20220712041646-755396d6fe77/go.mod h1:bta0vbR8Cajmq+oq3as0/iAWWnWqnYv+cas4ftX9KAw=
 tailscale.com v1.1.1-0.20220718172352-3c892d106c2e h1:Mq8xSdoqp/UabuPt405owY20/mt3q5z7fSruQQzC9Z8=
 tailscale.com v1.1.1-0.20220718172352-3c892d106c2e/go.mod h1:T9uKhlkxVPdSu1Qvp882evcS/hQ1+TAyZ7sJ/VACGRI=
+tailscale.com v1.1.1-0.20220726050820-dd3e91b6785e h1:ni75z+HerxM3XwcsfGmONIrFhv8OudSKLx1E5r1vEmA=
+tailscale.com v1.1.1-0.20220726050820-dd3e91b6785e/go.mod h1:JxNomQ7IdfGKzHL4luWYRxWbD05oeT4a8ZPxL8CWBn0=


### PR DESCRIPTION
Includes netaddr -> netip changes.

main.go getInterfaces still uses netaddr as it needs to return a net.IPNet (we'd need to add a new implementation in https://github.com/tailscale/tailscale/blob/7c671b0220a5a42303dd68c8b63a5baedcce885e/net/interfaces/interfaces.go#L110 to handle a different type).

Signed-off-by: Denton Gentry <dgentry@tailscale.com>