### PR TITLE
Allow the user to control which apps can use the VPN (WIP)

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -7,6 +7,8 @@
 	<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28"/>
 
+	<uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
+
 	<!-- Disable input emulation on ChromeOS -->
 	<uses-feature android:name="android.hardware.type.pc" android:required="false"/>
 

--- a/android/src/main/java/com/tailscale/ipn/App.java
+++ b/android/src/main/java/com/tailscale/ipn/App.java
@@ -38,6 +38,8 @@ import android.os.Environment;
 import android.os.Handler;
 import android.os.Looper;
 
+import android.util.Log;
+
 import android.Manifest;
 import android.webkit.MimeTypeMap;
 
@@ -86,9 +88,19 @@ public class App extends Application {
 
 	public DnsConfig dns = new DnsConfig(this);
 	public DnsConfig getDnsConfigObj() { return this.dns; }
+	public AppsConfig acfg = null;
 
 	@Override public void onCreate() {
 		super.onCreate();
+		Log.v("com.tailscale.ipn", "Loading apps: " + System.currentTimeMillis()/1000L);
+		try {
+			acfg = new AppsConfig(this, getEncryptedPrefs());
+			//acfg.printConfig();
+		} catch (Exception e) {
+			Log.e("com.tailscale.ipn", "exception", e);
+		}
+		Log.v("com.tailscale.ipn", "Apps loaded: " + System.currentTimeMillis()/1000L);
+
 		// Load and initialize the Go library.
 		Gio.init(this);
 		registerNetworkCallback();
@@ -96,7 +108,6 @@ public class App extends Application {
 		createNotificationChannel(NOTIFY_CHANNEL_ID, "Notifications", NotificationManagerCompat.IMPORTANCE_DEFAULT);
 		createNotificationChannel(STATUS_CHANNEL_ID, "VPN Status", NotificationManagerCompat.IMPORTANCE_LOW);
 		createNotificationChannel(FILE_CHANNEL_ID, "File transfers", NotificationManagerCompat.IMPORTANCE_DEFAULT);
-
 	}
 
 	private void registerNetworkCallback() {
@@ -121,6 +132,30 @@ public class App extends Application {
 				this.reportConnectivityChange();
 			}
 		});
+	}
+
+	public void setupApp(String packageName, boolean allowed){
+		acfg.setApp(packageName, allowed);
+	}
+
+	public int getTotalApps(){
+		return acfg.getTotalApps();
+	}
+
+	public String getPackageLabel(int i){
+		return acfg.getPackageLabel(i);
+	}
+
+	public String getPackageName(int i){
+		return acfg.getPackageName(i);
+	}
+
+	public boolean appIsAllowed(int i){
+		return acfg.appIsAllowed(i);
+	}
+
+	public String getIcon(String packageName) {
+		return acfg.getAppIcon(packageName);
 	}
 
 	public void startVPN() {

--- a/android/src/main/java/com/tailscale/ipn/AppsConfig.java
+++ b/android/src/main/java/com/tailscale/ipn/AppsConfig.java
@@ -1,0 +1,271 @@
+// Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package com.tailscale.ipn;
+
+import android.content.Context;
+import android.Manifest;
+import android.content.SharedPreferences;
+import android.util.Base64;
+import android.util.Log;
+import android.net.VpnService;
+import java.lang.reflect.Method;
+import android.content.pm.PackageManager;
+import android.content.pm.ApplicationInfo;
+import android.graphics.drawable.Drawable;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.lang.StringBuilder;
+
+public class AppsConfig {
+	private class AppConfig {
+		boolean allowed;
+		String icon;
+		String packageName;
+		String label;
+	}
+
+	private static final String PREFS_NAME = "disallowedApps";
+
+	private Context ctx;
+	private List<AppConfig> config;
+	private SharedPreferences sp;
+
+	public AppsConfig(Context ctx, SharedPreferences sp) {
+		this.ctx = ctx;
+		this.sp = sp;
+		PackageManager pm = this.ctx.getPackageManager();
+
+		config = new ArrayList<AppConfig>();
+		List<ApplicationInfo> instApps = getInstalledApps(pm);
+
+		for (int i = 0;i < instApps.size(); i++) {
+			ApplicationInfo appinfo = instApps.get(i);
+			AppConfig ac = new AppConfig();
+			ac.packageName = appinfo.packageName;
+			ac.allowed = true;
+			ac.icon = retrieveAppIcon(pm,appinfo);
+			CharSequence label = pm.getApplicationLabel(appinfo);
+			if(label != null){
+				ac.label = label.toString();
+			} else {
+				ac.label = ac.packageName;
+			}
+			config.add(ac);
+		}
+		readAppsConfig();
+	}
+
+	public VpnService.Builder build(VpnService.Builder b){
+		if(b == null)
+			return b;
+
+		for (int i = 0;i < config.size(); i++) {
+			AppConfig ac = config.get(i);
+			if(ac.allowed == false){
+				try {
+                        		b.addDisallowedApplication(ac.packageName);
+                		} catch (PackageManager.NameNotFoundException e) {
+                		
+				}
+			}
+		}
+
+		return b;
+	}
+	
+	public int getTotalApps(){
+		return config.size();
+	}
+
+	public boolean appIsAllowed(int i){
+		AppConfig ac = config.get(i);
+		if(ac != null){
+			return ac.allowed;
+		}
+
+		return false;
+	}
+
+	public String getPackageLabel(int i){
+		AppConfig ac = config.get(i);
+		if(ac != null){
+			return ac.label;
+		}
+
+		return null;
+	}
+
+	public String getPackageName(int i){
+		AppConfig ac = config.get(i);
+		if(ac != null){
+			return ac.packageName;
+		}
+
+		return null;
+	}
+
+	// Get the icon as a png encoded as a base64 string
+	public String getAppIcon(String packageName) {
+		if(config == null)
+			return null;
+
+		for(int i = 0;i < config.size(); i++) {
+			AppConfig ac = config.get(i);
+			if(ac.packageName.equals(packageName)){
+				return ac.icon;
+			}
+		}
+
+		return null;
+	}
+
+	// Allow,Disallow application to connect to the VPN
+	public void setApp(String packageName, boolean allowed) {
+		if(config == null || packageName == null || packageName.length() == 0)
+			return;
+		
+		Log.d("com.tailscale.ipn", "Disabling " + packageName);
+		AppConfig ac = null;
+
+		Log.d("com.tailscale.ipn", "size: " + config.size());
+		for (int i = 0;i < config.size(); i++) {
+			ac = config.get(i);
+			if(ac.packageName.equals(packageName) && 
+				ac.allowed != allowed){
+				//Log.d("com.tailscale.ipn", packageName);
+				ac.allowed = allowed;
+				config.set(i, ac);
+				writeAppsConfig();
+				return;
+			}
+		}
+	}
+
+	//returns a String like packageName;packageName;... or ""
+	private String getDisallowedApps() {
+		StringBuilder sb = new StringBuilder();
+		
+		for (int i = 0;i < config.size(); i++) {
+			AppConfig ac = config.get(i);
+			if(ac.allowed == false){
+				sb.append(ac.packageName);
+				sb.append(";");
+			}
+		}
+		
+		//Log.d("com.tailscale.ipn", sb.toString());
+		return sb.toString();
+	}
+
+	// persists blacklisted apps in the settings
+	public void writeAppsConfig() {
+		//Log.d("com.tailscale.ipn", "writeAppsConfig");
+		if(sp == null)
+			return;
+		//Log.d("com.tailscale.ipn", getDisallowedApps());
+		sp.edit().putString(PREFS_NAME, getDisallowedApps()).apply();
+	}
+
+	// read apps blacklisted in the settings
+	private void readAppsConfig() {
+		if(sp == null)
+			return;
+		
+		String disallowedApps = sp.getString(PREFS_NAME, "");
+		
+		if(disallowedApps.length() != 0){
+			List<String> strapps = 
+				Arrays.asList(disallowedApps.split(";"));
+			
+			if(strapps.size() > 0){
+				for(int i = 0; i < strapps.size(); i++){
+					for (int j = 0;j < config.size(); j++) {
+						AppConfig ac = config.get(j);
+						if(ac.packageName.equals(strapps.get(i))){
+							ac.allowed = false;
+							config.set(j, ac);
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Just for debug purposes prints all the apps and state
+	public void printConfig() {
+		if (config != null) {
+			for (int i = 0;i < config.size(); i++) {
+				AppConfig ac = config.get(i);
+				Log.v("com.tailscale.ipn", 
+					ac.packageName + " " + ac.allowed);
+				Log.v("com.tailscale.ipn", ac.icon);
+			}
+		}
+	}
+
+	// Retrieves the icon in png encoded in base64 from android using a PackageManager
+	private String retrieveAppIcon(PackageManager pm, ApplicationInfo info) {
+    		Drawable d = pm.getApplicationIcon(info);
+    		Bitmap mutableBitmap = Bitmap.createBitmap(48, 48, Bitmap.Config.ARGB_8888);
+    		Canvas canvas = new Canvas(mutableBitmap);
+    		d.setBounds(0, 0, 48, 48);
+    		d.draw(canvas);
+    		//Bitmap to png to ByteArrayOutputStream to byte[] to base64 String
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		//100 is the quality, but it is ignored for PNG
+		mutableBitmap.compress(Bitmap.CompressFormat.PNG, 100, baos);
+		//Return the png encoded as a base64 string
+		return Base64.encodeToString(baos.toByteArray(),Base64.DEFAULT);
+	}
+
+	// Returns a sorted list of installed apps with access to The Internet
+	private List<ApplicationInfo> getInstalledApps(PackageManager pm) {
+		if(this.ctx == null)
+			return null;
+		
+		if(pm == null)
+			pm = this.ctx.getPackageManager();
+
+		// Initialize variables
+		List<ApplicationInfo> ret = null;
+		List<ApplicationInfo> insApps = 
+			pm.getInstalledApplications(PackageManager.GET_META_DATA);
+
+		// This is done in the OpenVPN code
+		int androidSystemUid = 0;
+		ret = new ArrayList<ApplicationInfo>();
+
+		try {
+			ApplicationInfo system = 
+				pm.getApplicationInfo("android", PackageManager.GET_META_DATA);
+			if(system != null){
+		  		ret.add(system);
+				androidSystemUid = system.uid;
+			}
+		} catch (PackageManager.NameNotFoundException e) {
+			// it's ok if the "android" app doesn't exists
+		}
+
+		for (int i = 0;i < insApps.size(); i++){
+			ApplicationInfo app = insApps.get(i);
+			if (pm.checkPermission(
+					Manifest.permission.INTERNET, 
+					app.packageName) 
+				== PackageManager.PERMISSION_GRANTED 
+					&& app.uid != androidSystemUid){
+				if(app.packageName != "android")
+					ret.add(app);
+			}
+		}
+		
+		Collections.sort(ret, new ApplicationInfo.DisplayNameComparator(pm));
+		return ret;
+	}
+}

--- a/android/src/main/java/com/tailscale/ipn/IPNService.java
+++ b/android/src/main/java/com/tailscale/ipn/IPNService.java
@@ -48,14 +48,6 @@ public class IPNService extends VpnService {
 		return PendingIntent.getActivity(this, 0, new Intent(this, IPNActivity.class), PendingIntent.FLAG_UPDATE_CURRENT);
 	}
 
-	private void disallowApp(VpnService.Builder b, String name) {
-		try {
-			b.addDisallowedApplication(name);
-		} catch (PackageManager.NameNotFoundException e) {
-			return;
-		}
-	}
-
 	protected VpnService.Builder newBuilder() {
 		VpnService.Builder b = new VpnService.Builder()
 			.setConfigureIntent(configIntent())
@@ -65,18 +57,24 @@ public class IPNService extends VpnService {
 			b.setMetered(false); // Inherit the metered status from the underlying networks.
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
 			b.setUnderlyingNetworks(null); // Use all available networks.
-
+		
+		App app = (App) this.getApplication();
+		
 		// RCS/Jibe https://github.com/tailscale/tailscale/issues/2322
-		this.disallowApp(b, "com.google.android.apps.messaging");
-
+		app.setupApp("com.google.android.apps.messaging", false);
+		
 		// Stadia https://github.com/tailscale/tailscale/issues/3460
-		this.disallowApp(b, "com.google.stadia.android");
-
+		app.setupApp("com.google.stadia.android", false);
+		
 		// Android Auto https://github.com/tailscale/tailscale/issues/3828
-		this.disallowApp(b, "com.google.android.projection.gearhead");
+		app.setupApp("com.google.android.projection.gearhead", false);
 
 		// GoPro https://github.com/tailscale/tailscale/issues/2554
-		this.disallowApp(b, "com.gopro.smarty");
+		app.setupApp("com.gopro.smarty", false);
+
+		// Apply changes
+		b = app.acfg.build(b);
+		//app.acfg.printConfig();
 
 		return b;
 	}

--- a/cmd/tailscale/main.go
+++ b/cmd/tailscale/main.go
@@ -5,12 +5,16 @@
 package main
 
 import (
+	b64 "encoding/base64"
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/sha1"
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"image"
+	_ "image/png"
 	"io"
 	"log"
 	"mime"
@@ -64,6 +68,8 @@ type App struct {
 	targetsLoaded chan FileTargets
 	// invalidates receives whenever the window should be refreshed.
 	invalidates chan struct{}
+	
+	Apps []AppConfig
 }
 
 var (
@@ -100,6 +106,8 @@ type clientState struct {
 	backend   BackendState
 	// query is the search query, in lowercase.
 	query string
+	
+	Apps []AppConfig
 
 	Peers []UIPeer
 }
@@ -132,6 +140,13 @@ const (
 	FileSendComplete
 	FileSendFailed
 )
+
+type AppConfig struct {
+	allowed 	bool
+	icon		image.Image
+	packageName 	string
+	label		string
+}
 
 type Peer struct {
 	Label  string
@@ -185,6 +200,11 @@ type SetLoginServerEvent struct {
 	URL string
 }
 
+type AllowedAppsEvent struct {
+	packageName string
+	allowed bool
+}
+
 // UIEvent types.
 type (
 	ToggleEvent       struct{}
@@ -233,6 +253,9 @@ func main() {
 	}
 	a.store = newStateStore(a.jvm, a.appCtx)
 	interfaces.RegisterInterfaceGetter(a.getInterfaces)
+	log.Printf("Loading apps in go: " + time.Now().String())
+	a.loadAndroidApps()
+	log.Printf("Apps loaded in go: " + time.Now().String())
 	go func() {
 		if err := a.runBackend(); err != nil {
 			fatalErr(err)
@@ -244,6 +267,7 @@ func main() {
 		}
 	}()
 	app.Main()
+
 }
 
 func (a *App) runBackend() error {
@@ -587,6 +611,93 @@ func (a *App) downloadFile(b *ipnlocal.LocalBackend, f apitype.WaitingFile) (cer
 	return b.DeleteFile(f.Name)
 }
 
+func (a *App) setApp(packageName string, allowed bool) (error) {
+	err := jni.Do(a.jvm, func(env *jni.Env) error {
+		cls := jni.GetObjectClass(env, a.appCtx)
+		m := jni.GetMethodID(env, cls, "setupApp", "(Ljava/lang/String;Z)V")
+		err := jni.CallVoidMethod(env, a.appCtx, m, jni.Value(jni.JavaString(env, packageName)), jni.Value(jni.Bool(allowed)))
+		return err
+	})
+	return err
+}
+
+func (a *App) getIcon(packageName string) (image.Image, error) {
+	var enc string
+	err := jni.Do(a.jvm, func(env *jni.Env) error {
+		cls := jni.GetObjectClass(env, a.appCtx)
+		m := jni.GetMethodID(env, cls, "getIcon", "(Ljava/lang/String;)Ljava/lang/String;")
+		n, err := jni.CallObjectMethod(env, a.appCtx, m, jni.Value(jni.JavaString(env, packageName)))
+		enc = jni.GoString(env, jni.String(n))
+		return err
+	})
+	if(err != nil){
+		return nil, err
+	}
+	dec, err := b64.StdEncoding.DecodeString(enc)
+	if(err != nil){
+		return nil, err
+	}
+	img, _, err := image.Decode(bytes.NewReader(dec))
+    	if err != nil {
+        	return nil, err
+    	}
+	return img, err
+}
+
+func (a *App) getTotalApps() (int32, error) {
+	var size int32 = 0
+	err := jni.Do(a.jvm, func(env *jni.Env) error {
+		cls := jni.GetObjectClass(env, a.appCtx)
+		getTotalApps := jni.GetMethodID(env, cls, "getTotalApps", "()I")
+		ret, err := jni.CallIntMethod(env, a.appCtx, getTotalApps)
+		if err != nil {
+			return err
+		}
+		size = ret
+		return nil
+	})
+	return size, err
+}
+
+func (a *App) getPackageLabel(i int32) (string, error) {
+	var ret string
+	err := jni.Do(a.jvm, func(env *jni.Env) error {
+		cls := jni.GetObjectClass(env, a.appCtx)
+		m := jni.GetMethodID(env, cls, "getPackageLabel", "(I)Ljava/lang/String;")
+		n, err := jni.CallObjectMethod(env, a.appCtx, m, jni.Value(i))
+		ret = jni.GoString(env, jni.String(n))
+		return err
+
+	})
+	return ret, err
+}
+
+func (a *App) getPackageName(i int32) (string, error) {
+	var ret string
+	err := jni.Do(a.jvm, func(env *jni.Env) error {
+		cls := jni.GetObjectClass(env, a.appCtx)
+		m := jni.GetMethodID(env, cls, "getPackageName", "(I)Ljava/lang/String;")
+		n, err := jni.CallObjectMethod(env, a.appCtx, m, jni.Value(i))
+		ret = jni.GoString(env, jni.String(n))
+		return err
+
+	})
+	return ret, err
+}
+
+func (a *App) appIsAllowed(i int32) (bool, error) {
+	var ret bool
+	err := jni.Do(a.jvm, func(env *jni.Env) error {
+		cls := jni.GetObjectClass(env, a.appCtx)
+		m := jni.GetMethodID(env, cls, "appIsAllowed", "(I)Z")
+		n, err := jni.CallBooleanMethod(env, a.appCtx, m, jni.Value(i))
+		ret = n
+		return err
+
+	})
+	return ret, err
+}
+
 // openURI calls a.appCtx.getContentResolver().openFileDescriptor on uri and
 // mode and returns the detached file descriptor.
 func (a *App) openURI(uri, mode string) (*os.File, error) {
@@ -839,6 +950,7 @@ func (a *App) runUI() error {
 	}
 	var ops op.Ops
 	state := new(clientState)
+	state.Apps = a.Apps
 	var (
 		// activity is the most recent Android Activity reference as reported
 		// by Gio ViewEvents.
@@ -1014,6 +1126,42 @@ func (a *App) attachPeer(act jni.Object) {
 	}
 }
 
+func (a *App) loadAndroidApps() {
+	//Load Android Applications
+	total, err := a.getTotalApps()
+	if(err != nil){
+		log.Printf("Error: %v",err)
+	} else {
+		log.Printf("Exiting... %d", total)
+	}
+	if total != int32(len(a.Apps)){
+		var apps []AppConfig
+		var i int32 = 0
+		for i < total {
+			pn, err := a.getPackageName(int32(i))
+			if(err != nil){
+				log.Printf("Error: %v", err)
+			}
+			label, err := a.getPackageLabel(int32(i))
+			if(err != nil){
+				log.Printf("Error: %v", err)
+			}
+			allowed, err := a.appIsAllowed(int32(i))
+			if(err != nil){
+				log.Printf("Error: %v", err)
+			}
+			icon, err := a.getIcon(pn)
+			if(err != nil){
+				log.Printf("Error: %v", err)
+			}
+			//log.Printf("%v %v %v", pn, icon, allowed)
+			i = i + 1
+			apps = append(apps, AppConfig{allowed: allowed, icon: icon, label: label, packageName: pn})
+		}
+		a.Apps = apps
+	}
+}
+
 func (a *App) updateState(act jni.Object, state *clientState) {
 	if act != 0 && state.browseURL != "" {
 		a.browseToURL(act, state.browseURL)
@@ -1098,6 +1246,14 @@ func requestBackend(e UIEvent) {
 func (a *App) processUIEvents(w *app.Window, events []UIEvent, act jni.Object, state *clientState, files []File) {
 	for _, e := range events {
 		switch e := e.(type) {
+		case AllowedAppsEvent:
+		        log.Printf("tailscale Clicked AllowedApps")
+			var ev AllowedAppsEvent = AllowedAppsEvent(e)
+			log.Printf("%v %v",ev.packageName, ev.allowed)
+			err := a.setApp(ev.packageName, ev.allowed)
+			if (err != nil){
+				log.Printf("Error configuring app: %v", err)
+			}
 		case ReauthEvent:
 			method, _ := a.store.ReadString(loginMethodPrefKey, loginMethodWeb)
 			switch method {


### PR DESCRIPTION
This PR allows to control which apps are allowed to connect to the VPN, it adds a new entry to the menu once the user has been connected and display a dialog where the different apps can be enabled/disabled. The user needs to enable/disable the VPN again to apply the changes.

Signed-off-by: Víctor Enríquez <188838+vquicksilver@users.noreply.github.com>