### PR TITLE
UI: remove "No internet connection"

### DIFF
--- a/cmd/tailscale/main.go
+++ b/cmd/tailscale/main.go
@@ -495,11 +495,7 @@ func (a *App) runBackend() error {
 					notifyVPNClosed()
 				}
 			}
-		case connected := <-onConnectivityChange:
-			if state.LostInternet != !connected {
-				log.Printf("LostInternet state change: %v -> %v", state.LostInternet, !connected)
-			}
-			state.LostInternet = !connected
+		case <-onConnectivityChange:
 			if b != nil {
 				go b.LinkChange()
 			}

--- a/cmd/tailscale/ui.go
+++ b/cmd/tailscale/ui.go
@@ -510,15 +510,13 @@ func (ui *UI) layout(gtx layout.Context, sysIns system.Insets, state *clientStat
 				}
 				return ui.layoutSearchbar(gtx, sysIns)
 			case 4:
-				if !needsLogin || state.backend.LostInternet {
+				if !needsLogin {
 					return D{}
 				}
 				return ui.layoutSignIn(gtx, &state.backend)
 			case 5:
-				if !state.backend.LostInternet {
-					return D{}
-				}
-				return ui.layoutDisconnected(gtx)
+				// Formerly "No internet connection", which has been removed.
+				return D{}
 			default:
 				if needsLogin {
 					return D{}
@@ -798,29 +796,6 @@ func (ui *UI) withLoader(gtx layout.Context, loading bool, w layout.Widget) layo
 			})
 		}),
 	)
-}
-
-// layoutDisconnected lays out the "please connect to the internet"
-// message.
-func (ui *UI) layoutDisconnected(gtx layout.Context) layout.Dimensions {
-	return layout.UniformInset(unit.Dp(16)).Layout(gtx, func(gtx C) D {
-		return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
-			layout.Rigid(func(gtx C) D {
-				return layout.Inset{Top: unit.Dp(8)}.Layout(gtx, func(gtx C) D {
-					title := material.H6(ui.theme, "No internet connection")
-					title.Alignment = text.Middle
-					return title.Layout(gtx)
-				})
-			}),
-			layout.Rigid(func(gtx C) D {
-				return layout.Inset{Top: unit.Dp(8)}.Layout(gtx, func(gtx C) D {
-					msg := material.Body2(ui.theme, "Tailscale is paused while your device is offline. Please reconnect to the internet.")
-					msg.Alignment = text.Middle
-					return msg.Layout(gtx)
-				})
-			}),
-		)
-	})
 }
 
 // layoutIntro lays out the intro page with the logo and terms.


### PR DESCRIPTION
This has never worked well. I think we'd need to periodically re-check
link state, and possibly hook up a generate_204 function, to make this
really work.

Fixes https://github.com/tailscale/tailscale/issues/5422

Signed-off-by: Denton Gentry <dgentry@tailscale.com>