### PR TITLE
android: add about dialog with license link

### DIFF
--- a/cmd/tailscale/main.go
+++ b/cmd/tailscale/main.go
@@ -193,6 +193,7 @@ type (
 	WebAuthEvent      struct{}
 	GoogleAuthEvent   struct{}
 	LogoutEvent       struct{}
+	OSSLicensesEvent  struct{}
 	BeExitNodeEvent   bool
 	ExitAllowLANEvent bool
 )
@@ -1134,6 +1135,8 @@ func (a *App) processUIEvents(w *app.Window, events []UIEvent, act jni.Object, s
 			a.updateState(act, state)
 		case FileSendEvent:
 			a.sendFiles(e, files)
+		case OSSLicensesEvent:
+			a.setURL("https://tailscale.com/licenses/android")
 		}
 	}
 }


### PR DESCRIPTION
Add "about" menu item in both the logged out and logged in menus.  About dialog shows Tailscale version and link to URL with open source licenses.

The version entry in the about dialog does duplicate the version at the top of the logged-out menu.  Maybe that's okay?  Maybe we remove it from the menu?  I seem to recall it was really only there so that the menu wasn't completely empty if you hadn't yet activated the debug menu?  We could also remove it from the About dialog; I just added it because it seemed to make sense.

Updates tailscale/corp#5780

<img width="257" alt="Screen Shot 2022-09-09 at 4 38 16 PM" src="https://user-images.githubusercontent.com/1112/189459629-e1aaabae-90f5-47c2-9ba0-145711938ee4.png">