### PR TITLE
build.gradle: update to SDK31

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ android {
 	compileSdkVersion 30
 	defaultConfig {
 		minSdkVersion 22
-		targetSdkVersion 30
+		targetSdkVersion 31
 		versionCode 133
 		versionName "1.33.21-t63ad49890-g80dfbd8a0c5"
 	}

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -22,7 +22,8 @@
 			android:theme="@style/Theme.GioApp"
 			android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|keyboardHidden"
 			android:windowSoftInputMode="adjustResize"
-			android:launchMode="singleTask">
+			android:launchMode="singleTask"
+			android:exported="true">
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />
 				<category android:name="android.intent.category.LAUNCHER" />
@@ -55,7 +56,8 @@
 			</intent-filter>
 		</activity>
 		<service android:name=".IPNService"
-			android:permission="android.permission.BIND_VPN_SERVICE">
+			android:permission="android.permission.BIND_VPN_SERVICE"
+			android:exported="false">
 			<intent-filter>
 				<action android:name="android.net.VpnService"/>
 			</intent-filter>
@@ -64,7 +66,8 @@
 			android:name=".QuickToggleService"
 			android:icon="@drawable/ic_tile"
 			android:label="@string/tile_name"
-			android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+			android:permission="android.permission.BIND_QUICK_SETTINGS_TILE"
+			android:exported="true">
 		<intent-filter>
 			<action android:name="android.service.quicksettings.action.QS_TILE"/>
 		</intent-filter>

--- a/android/src/main/java/com/tailscale/ipn/IPNService.java
+++ b/android/src/main/java/com/tailscale/ipn/IPNService.java
@@ -45,7 +45,8 @@ public class IPNService extends VpnService {
 	}
 
 	private PendingIntent configIntent() {
-		return PendingIntent.getActivity(this, 0, new Intent(this, IPNActivity.class), PendingIntent.FLAG_UPDATE_CURRENT);
+		return PendingIntent.getActivity(this, 0, new Intent(this, IPNActivity.class),
+			PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 	}
 
 	private void disallowApp(VpnService.Builder b, String name) {


### PR DESCRIPTION
Required for apps to update in the Play Store after November 1.

This requires:
- manifest must specify if Intents are exported.
- PendingIntent must declare FLAG_IMMUTABLE or MUTABLE

Signed-off-by: Denton Gentry <dgentry@tailscale.com>