### PR TITLE
cmd/tailscale: fix alternate ControlURL handling.

### DIFF
--- a/cmd/tailscale/ui.go
+++ b/cmd/tailscale/ui.go
@@ -396,8 +396,9 @@ func (ui *UI) layout(gtx layout.Context, sysIns system.Insets, state *clientStat
 
 	if ui.loginServerSave.Clicked() {
 		text := ui.loginServer.Text()
-		ui.showMessage(gtx, "Login server saved, relaunch the app")
+		ui.showMessage(gtx, "Login server saved")
 		events = append(events, SetLoginServerEvent{URL: text})
+		ui.setLoginServer = false
 	}
 	if ui.loginServerCancel.Clicked() {
 		ui.setLoginServer = false
@@ -725,7 +726,7 @@ func (ui *UI) layoutSignIn(gtx layout.Context, state *BackendState) layout.Dimen
 				layout.Rigid(func(gtx C) D {
 					return layout.Inset{Bottom: unit.Dp(16)}.Layout(gtx, func(gtx C) D {
 						return border.Layout(gtx, func(gtx C) D {
-							button := material.Button(ui.theme, &ui.loginServerSave, "Save and restart")
+							button := material.Button(ui.theme, &ui.loginServerSave, "Save")
 							button.Background = color.NRGBA{} // transparent
 							button.Color = rgb(textColor)
 							return button.Layout(gtx)


### PR DESCRIPTION
With the Fast User Switching support in Tailscale 1.34, it is no longer necessary (nor sufficient) to exit and restart the app, as the settings are saved upon first connection.

Therefore:
- do not restart the app after changing the control URL, just go back to the authentication screen.
- call `ipn/ipnlocal/local.go:Start()` to reinitialize the backend using the new auth URL.

Fixes https://github.com/tailscale/tailscale/issues/6671

Signed-off-by: Denton Gentry <dgentry@tailscale.com>