### PR TITLE
IPNService: add Chromecast to the apps allowed to bypass the VPN.

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/IPNService.java
+++ b/android/src/main/java/com/tailscale/ipn/IPNService.java
@@ -83,6 +83,9 @@ public class IPNService extends VpnService {
 		this.disallowApp(b, "com.sonos.acr");
 		this.disallowApp(b, "com.sonos.acr2");
 
+		// Google Chromecast https://github.com/tailscale/tailscale/issues/3636
+		this.disallowApp(b, "com.google.android.apps.chromecast.app");
+
 		return b;
 	}
 


### PR DESCRIPTION
Needed for LAN discovery of Chromecast devices.
Fixes https://github.com/tailscale/tailscale/issues/3636

Signed-off-by: Denton Gentry <dgentry@tailscale.com>