### PR TITLE
Prevent connecting loops when using connect intent more than once

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/App.java
+++ b/android/src/main/java/com/tailscale/ipn/App.java
@@ -106,9 +106,6 @@ public class App extends Application {
 				NetworkInfo active = cMgr.getActiveNetworkInfo();
 				// https://developer.android.com/training/monitoring-device-state/connectivity-status-type
 				boolean isConnected = active != null && active.isConnectedOrConnecting();
-				if (isConnected) {
-					((App)getApplicationContext()).autoConnect = false;
-				}
 				onConnectivityChanged(isConnected);
 			}
 

--- a/android/src/main/java/com/tailscale/ipn/IPNService.java
+++ b/android/src/main/java/com/tailscale/ipn/IPNService.java
@@ -22,6 +22,7 @@ public class IPNService extends VpnService {
 
 	@Override public int onStartCommand(Intent intent, int flags, int startId) {
 		if (intent != null && ACTION_DISCONNECT.equals(intent.getAction())) {
+			((App)getApplicationContext()).autoConnect = false;
 			close();
 			return START_NOT_STICKY;
 		}

--- a/android/src/main/java/com/tailscale/ipn/StartVPNWorker.java
+++ b/android/src/main/java/com/tailscale/ipn/StartVPNWorker.java
@@ -10,11 +10,6 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.PackageManager;
-import android.net.ConnectivityManager;
-import android.net.Network;
-import android.net.NetworkCapabilities;
-import android.net.NetworkInfo;
 import android.net.VpnService;
 import android.os.Build;
 import androidx.work.Worker;
@@ -29,11 +24,7 @@ public final class StartVPNWorker extends Worker {
     }
 
     @Override public Result doWork() {
-        // Check if the app's VPN is already connected
         App app = ((App)getApplicationContext());
-        if (isVpnConnected(app)) {
-            return Result.success();
-        }
 
         // We will start the VPN from the background
         app.autoConnect = true;
@@ -71,25 +62,5 @@ public final class StartVPNWorker extends Worker {
 
             return Result.failure();
         }
-    }
-
-    public static boolean isVpnConnected(Context context) {
-        ConnectivityManager connectivityManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
-
-        if (connectivityManager != null) {
-            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
-                Network activeNetwork = connectivityManager.getActiveNetwork();
-                NetworkCapabilities networkCapabilities = connectivityManager.getNetworkCapabilities(activeNetwork);
-                if (networkCapabilities != null) {
-                    return networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN);
-                }
-            } else {
-                // Deprecated method for API levels below 23 (Android 6.0)
-                NetworkInfo networkInfo = connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_VPN);
-                return networkInfo != null && networkInfo.isConnected();
-            }
-        }
-
-        return false;
     }
 }


### PR DESCRIPTION
Added a check to check if the VPN is connected before triggering the connect behaviour.

Was introduced in https://github.com/tailscale/tailscale-android/pull/87

Fixes: https://github.com/tailscale/tailscale/issues/8013