### PR TITLE
Makefile: fix versionCode replacement and cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ export GOROOT := # Unset
 all: $(APK)
 
 tag_release:
-	sed -i'.bak' 's/versionCode [[:digit:]]\+/versionCode $(VERSIONCODE_PLUSONE)/' android/build.gradle
-	sed -i'.bak' 's/versionName .*/versionName "$(VERSION_LONG)"/' android/build.gradle
+	sed -i'.bak' 's/versionCode $(VERSIONCODE)/versionCode $(VERSIONCODE_PLUSONE)/' android/build.gradle && rm android/build.gradle.bak
+	sed -i'.bak' 's/versionName .*/versionName "$(VERSION_LONG)"/' android/build.gradle && rm android/build.gradle.bak
 	git commit -sm "android: bump version code" android/build.gradle
 	git tag -a "$(VERSION_LONG)"
 


### PR DESCRIPTION
I'm not sure why [[:digit:]] worked before but not now (BSD vs GNU sed maybe?), but since we already have the old VERSIONCODE, just replace it directly. Also cleanup the android/build.gradle.bak file.