### PR TITLE
android: update gradle version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,14 +4,14 @@ buildscript {
 		jcenter()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:4.2.0'
+		classpath 'com.android.tools.build:gradle:7.3.0'
 	}
 }
 
 allprojects {
 	repositories {
 		google()
-		jcenter()
+		mavenCentral()
 		flatDir {
 			dirs 'libs'
 		}
@@ -51,7 +51,7 @@ dependencies {
 	implementation "androidx.security:security-crypto:1.1.0-alpha03"
 	implementation "androidx.work:work-runtime:2.7.0"
 	implementation ':ipn@aar'
-	testCompile "junit:junit:4.12"
+	testImplementation "junit:junit:4.12"
 
 	// Non-free dependencies.
 	playImplementation 'com.google.android.gms:play-services-auth:18.0.0'

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=3239b5ed86c3838a37d983ac100573f64c1f3fd8e1eb6c89fa5f9529b5ec091d
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionSha256Sum=38f66cd6eef217b4c35855bb11ea4e9fbc53594ccccb5fb82dfd317ef8c2c5a3
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
-Update Gradle version
-Replace jcenter() with mavenCentral() because of jcenter deprecation -Use testImplementation instead of the obsolete testCompile

Fixes #12997

Tested with docker