### PR TITLE
version: fix result from tailscale-version.sh when not using a git source

### DIFF
--- a/version/tailscale-version.sh
+++ b/version/tailscale-version.sh
@@ -11,10 +11,10 @@ set -euo pipefail
 
 go_list=$(go list -m tailscale.com)
 # go list outputs `tailscale.com <version>`. Extract the version.
-mod_version=${go_list##* }
+mod_version=${go_list#tailscale.com}
 
 if [ -z "$mod_version" ]; then
-	echo "no version reported by go list -m tailscale.com: $go_list"
+	echo >&2 "no version reported by go list -m tailscale.com: $go_list"
 	exit 1
 fi
 


### PR DESCRIPTION
If the developer has used `go mod vendor` or `go work use ../tailscale` then the version script was returning "tailscale.com" instead of hitting the error case.

This now makes the outcome with the Makefile slightly worse, which needs to be fixed up next.

Updates #cleanup