### PR TITLE
android: upgrade gradle plugin runtime to 8.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,11 @@ jobs:
 
     - name: Check out code
       uses: actions/checkout@v3
+    - name: Switch to Java 17 # Note: 17 is pre-installed on ubuntu-latest
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '17'
 
     - name: Build APK
       run: make tailscale-debug.apk

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # This is a Dockerfile for creating a build environment for
 # tailscale-android.
 
-FROM --platform=linux/amd64 eclipse-temurin:11-jdk
+FROM --platform=linux/amd64 eclipse-temurin:20-jdk
 
 # To enable running android tools such as aapt
 RUN apt-get update && apt-get -y upgrade

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,10 +1,10 @@
 buildscript {
 	repositories {
 		google()
-		jcenter()
+		mavenCentral()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:7.4.2'
+		classpath 'com.android.tools.build:gradle:8.1.0'
 	}
 }
 
@@ -22,7 +22,7 @@ apply plugin: 'com.android.application'
 
 android {
 	ndkVersion "23.1.7779620"
-	compileSdkVersion 31
+	compileSdk 31
 	defaultConfig {
 		minSdkVersion 22
 		targetSdkVersion 31

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,1 +1,4 @@
+android.defaults.buildfeatures.buildconfig=true
+android.nonFinalResIds=false
+android.nonTransitiveRClass=false
 android.useAndroidX=true


### PR DESCRIPTION
Another upgrade recommended by Android Studio, again this is just upgrading the build tooling, and not yet changing any of the runtime side dependencies or behaviors.

We switch from jcenter to mavenCentral as advised in the build output, as jcenter has shutdown.

Updates #cleanup