### PR TITLE
cmd/tailscale: rebind magicsock.Conn onConnect

### DIFF
--- a/cmd/tailscale/main.go
+++ b/cmd/tailscale/main.go
@@ -498,6 +498,17 @@ func (a *App) runBackend() error {
 						return nil // even on error. see big TODO above.
 					})
 				})
+				log.Printf("onConnect: rebind required")
+				// TODO(catzkorn): When we start the android application
+				// we bind sockets before we have access to the VpnService.protect()
+				// function which is needed to avoid routing loops. When we activate
+				// the service we get access to the protect, but do not retrospectively
+				// protect the sockets already opened, which breaks connectivity.
+				// As a temporary fix, we rebind and protect the magicsock.Conn on connect
+				// which restores connectivity.
+				// See https://github.com/tailscale/corp/issues/13814
+				b.backend.DebugRebind()
+
 				service = s
 				return nil
 			})


### PR DESCRIPTION
We have been getting into routing loops due to the timing of when we bind sockets on starting the tailscale app. At this point, we do not have access to `VpnService.protect()` and are unable to protect the magicsock sockets, which causes a routing loop issue until we forcibly rebind about 10 minutes into the service being started.

This change rebinds when we detect that the protect function is no longer nil, and restores connectivity.

Updates tailscale/corp#13814