### PR TITLE
build.gradle: update targetSdkVersion to 33.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ android {
 	compileSdk 31
 	defaultConfig {
 		minSdkVersion 22
-		targetSdkVersion 31
+		targetSdkVersion 33
 		versionCode 175
 		versionName "1.47.108-td5ac18d2c-g4b67f47e88f"
 	}

--- a/android/src/main/java/com/tailscale/ipn/App.java
+++ b/android/src/main/java/com/tailscale/ipn/App.java
@@ -210,12 +210,7 @@ public class App extends Application {
 	// get user defined nickname from Settings
 	// returns null if not available
 	private String getUserConfiguredDeviceName() {
-		String nameFromSystemBluetooth = Settings.System.getString(getContentResolver(), "bluetooth_name");
-		String nameFromSecureBluetooth = Settings.Secure.getString(getContentResolver(), "bluetooth_name");
 		String nameFromSystemDevice = Settings.Secure.getString(getContentResolver(), "device_name");
-
-		if (!isEmpty(nameFromSystemBluetooth)) return nameFromSystemBluetooth;
-		if (!isEmpty(nameFromSecureBluetooth)) return nameFromSecureBluetooth;
 		if (!isEmpty(nameFromSystemDevice)) return nameFromSystemDevice;
 		return null;
 	}


### PR DESCRIPTION
"bluetooth_name" cannot be accessed after SDK 31, remove it from getUserConfiguredDeviceName().

Fixes https://github.com/tailscale/tailscale/issues/8955