### PR TITLE
Makefile: add assertion to ensure the go toolchain is correct

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,11 @@ androidpath:
 	@echo "export ANDROID_SDK_ROOT=$(ANDROID_SDK_ROOT)"
 	@echo 'export PATH=$(ANDROID_HOME)/cmdline-tools/latest/bin:$(ANDROID_HOME)/platform-tools:$$PATH'
 
+
+# Assert that the go toolchain referred to by TOOLCHAINDIR is in fact the
+# one that `go` in the current PATH is using.
 toolchain: $(TOOLCHAINDIR)/bin/go
+	test `go env GOROOT` = $(TOOLCHAINDIR)
 
 android/libs:
 	mkdir -p android/libs


### PR DESCRIPTION
This should provide an earlier error for cases such as tailscale/tailscale#8987 if the error comes from a failure to fetch the toolchain, or a change that forces an alternative GOROOT by some other means.

Updates tailscale/tailscale#8987