### PR TITLE
Build fixes

### DIFF
--- a/cmd/tailscale/backend.go
+++ b/cmd/tailscale/backend.go
@@ -143,7 +143,7 @@ func newBackend(dataDir string, jvm *jni.JVM, appCtx jni.Object, store *stateSto
 	}
 	sys.Set(engine)
 	b.logIDPublic = logID.Public().String()
-	ns, err := netstack.Create(logf, sys.Tun.Get(), engine, sys.MagicSock.Get(), dialer, sys.DNSManager.Get())
+	ns, err := netstack.Create(logf, sys.Tun.Get(), engine, sys.MagicSock.Get(), dialer, sys.DNSManager.Get(), sys.ProxyMapper())
 	if err != nil {
 		return nil, fmt.Errorf("netstack.Create: %w", err)
 	}

--- a/cmd/tailscale/ui.go
+++ b/cmd/tailscale/ui.go
@@ -366,8 +366,8 @@ func (ui *UI) layout(gtx layout.Context, sysIns system.Insets, state *clientStat
 		userID = netmap.User()
 		expiry = netmap.Expiry
 		localName = netmap.SelfNode.DisplayName(false)
-		if addrs := netmap.Addresses; len(addrs) > 0 {
-			localAddr = addrs[0].Addr().String()
+		if addrs := netmap.GetAddresses(); addrs.Len() > 0 {
+			localAddr = addrs.At(0).Addr().String()
 		}
 	}
 	if p := state.backend.Prefs; p != nil {

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	golang.org/x/exp/shiny v0.0.0-20220827204233-334a2380cb91
 	golang.org/x/sys v0.11.0
 	inet.af/netaddr v0.0.0-20220617031823-097006376321
-	tailscale.com v1.1.1-0.20230912221414-727b1432a881
+	tailscale.com v1.1.1-0.20230925222950-651620623b10
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -717,5 +717,5 @@ sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 software.sslmate.com/src/go-pkcs12 v0.2.0 h1:nlFkj7bTysH6VkC4fGphtjXRbezREPgrHuJG20hBGPE=
 software.sslmate.com/src/go-pkcs12 v0.2.0/go.mod h1:23rNcYsMabIc1otwLpTkCCPwUq6kQsTyowttG/as0kQ=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=
-tailscale.com v1.1.1-0.20230912221414-727b1432a881 h1:GwhTlkWKIWDRrZndSBytvs7xfhbH2EyA9IGjkMwUoNc=
-tailscale.com v1.1.1-0.20230912221414-727b1432a881/go.mod h1:L/6mVRFA/zTI/46+8cHMddZAvb1xf2LTI/LJ/D8CbeM=
+tailscale.com v1.1.1-0.20230925222950-651620623b10 h1:WNvgEIxeDAuQRMRHHBESIui06xCiaorZftMg0a4Bu0o=
+tailscale.com v1.1.1-0.20230925222950-651620623b10/go.mod h1:lBw7+Mw2d7rea3kefGjYWN8IJkB5dyaakMNMOinNGDo=


### PR DESCRIPTION
These changes pick up the latest OSS and fixes the build.

I've split it into two commits so that I can `cherry-pick` the breakage fix onto 1.50.0.