### PR TITLE
version: handle whitespace in ${mod_version}

### DIFF
--- a/version/tailscale-version.sh
+++ b/version/tailscale-version.sh
@@ -33,7 +33,7 @@ cd $tailscale_clone
 git reset --hard -q
 git clean -d -x -f
 git fetch -q --all --tags
-git checkout -q "$mod_version"
+git checkout -q ${mod_version}
 
 eval $(./build_dist.sh shellvars)
 git_hash=$(git rev-parse HEAD)


### PR DESCRIPTION
5ca195b1097fad0b750e1ac04bdd49ed3313c123 changed the shell code to determine the OSS module version:
-mod_version=${go_list##* }
+mod_version=${go_list#tailscale.com}

The intent is fine but the original code also consumed a whitespace from the go.mod content:
        tailscale.com v1.52.0
original: "v1.52.0"
updated:  " v1.52.0"

At least for me, "make tag_release" no longer works:
    error: pathspec ' v1.54.0' did not match any file(s) known to git
Note the extra space at the start of the pathspec.

It is apparently not broken for everyone, possibly related to versions of other tools I have installed like maybe git.

I don't want to just put the whitespace trimming back the way it was, that seems fragile. Instead, quote ${mod_version} in a way which won't be sensitive to extra whitespace.