### PR TITLE
Implement USE_EXIT_NODE intent

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -90,6 +90,7 @@
             <intent-filter>
                 <action android:name="com.tailscale.ipn.CONNECT_VPN" />
                 <action android:name="com.tailscale.ipn.DISCONNECT_VPN" />
+                <action android:name="com.tailscale.ipn.USE_EXIT_NODE" />
             </intent-filter>
         </receiver>
 

--- a/android/src/main/java/com/tailscale/ipn/App.kt
+++ b/android/src/main/java/com/tailscale/ipn/App.kt
@@ -335,6 +335,7 @@ class App : UninitializedApp(), libtailscale.AppContext {
 open class UninitializedApp : Application() {
   companion object {
     const val STATUS_NOTIFICATION_ID = 1
+    const val STATUS_EXIT_NODE_FAILURE_NOTIFICATION_ID = 2
     const val STATUS_CHANNEL_ID = "tailscale-status"
 
     // Key for shared preference that tracks whether or not we're able to start
@@ -388,6 +389,10 @@ open class UninitializedApp : Application() {
   }
 
   fun notifyStatus(vpnRunning: Boolean) {
+      notifyStatus(buildStatusNotification(vpnRunning))
+  }
+
+  fun notifyStatus(notification: Notification) {
     if (ActivityCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) !=
         PackageManager.PERMISSION_GRANTED) {
       // TODO: Consider calling
@@ -399,7 +404,7 @@ open class UninitializedApp : Application() {
       // for ActivityCompat#requestPermissions for more details.
       return
     }
-    notificationManager.notify(STATUS_NOTIFICATION_ID, buildStatusNotification(vpnRunning))
+    notificationManager.notify(STATUS_NOTIFICATION_ID, notification)
   }
 
   fun buildStatusNotification(vpnRunning: Boolean): Notification {

--- a/android/src/main/java/com/tailscale/ipn/IPNReceiver.java
+++ b/android/src/main/java/com/tailscale/ipn/IPNReceiver.java
@@ -6,6 +6,7 @@ package com.tailscale.ipn;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import androidx.work.Data;
 
 import androidx.work.OneTimeWorkRequest;
 import androidx.work.WorkManager;
@@ -20,6 +21,8 @@ public class IPNReceiver extends BroadcastReceiver {
     public static final String INTENT_CONNECT_VPN = "com.tailscale.ipn.CONNECT_VPN";
     public static final String INTENT_DISCONNECT_VPN = "com.tailscale.ipn.DISCONNECT_VPN";
 
+    private static final String INTENT_USE_EXIT_NODE = "com.tailscale.ipn.USE_EXIT_NODE";
+
     @Override
     public void onReceive(Context context, Intent intent) {
         WorkManager workManager = WorkManager.getInstance(context);
@@ -29,6 +32,14 @@ public class IPNReceiver extends BroadcastReceiver {
             workManager.enqueue(new OneTimeWorkRequest.Builder(StartVPNWorker.class).build());
         } else if (Objects.equals(intent.getAction(), INTENT_DISCONNECT_VPN)) {
             workManager.enqueue(new OneTimeWorkRequest.Builder(StopVPNWorker.class).build());
+        }
+        else if (Objects.equals(intent.getAction(), INTENT_USE_EXIT_NODE)) {
+            String exitNode = intent.getStringExtra("exitNode");
+            boolean allowLanAccess = intent.getBooleanExtra("allowLanAccess", false);
+            Data.Builder workData = new Data.Builder();
+            workData.putString(UseExitNodeWorker.EXIT_NODE_NAME, exitNode);
+            workData.putBoolean(UseExitNodeWorker.ALLOW_LAN_ACCESS, allowLanAccess);
+            workManager.enqueue(new OneTimeWorkRequest.Builder(UseExitNodeWorker.class).setInputData(workData.build()).build());
         }
     }
 }

--- a/android/src/main/java/com/tailscale/ipn/UseExitNodeWorker.kt
+++ b/android/src/main/java/com/tailscale/ipn/UseExitNodeWorker.kt
@@ -1,0 +1,109 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+package com.tailscale.ipn
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.NotificationCompat
+import androidx.work.CoroutineWorker
+import androidx.work.Data
+import androidx.work.WorkerParameters
+import com.tailscale.ipn.UninitializedApp.Companion.STATUS_CHANNEL_ID
+import com.tailscale.ipn.UninitializedApp.Companion.STATUS_EXIT_NODE_FAILURE_NOTIFICATION_ID
+import com.tailscale.ipn.ui.localapi.Client
+import com.tailscale.ipn.ui.model.Ipn
+import com.tailscale.ipn.ui.notifier.Notifier
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+
+class UseExitNodeWorker(
+    appContext: Context,
+    workerParams: WorkerParameters
+) : CoroutineWorker(appContext, workerParams) {
+    override suspend fun doWork(): Result {
+        suspend fun runAndGetResult(): String? {
+            val exitNodeName = inputData.getString(EXIT_NODE_NAME)
+
+            val exitNodeId = if (exitNodeName.isNullOrEmpty()) {
+                null
+            } else {
+                if (!UninitializedApp.get().isAbleToStartVPN()) {
+                    return "VPN is not ready to start"
+                }
+
+                val peers =
+                    (Notifier.netmap.value
+                        ?: run { return@runAndGetResult "Tailscale is not setup" })
+                        .Peers ?: run { return@runAndGetResult "No peers found" }
+
+                val filteredPeers = peers.filter {
+                    it.displayName == exitNodeName
+                }.toList()
+
+                if (filteredPeers.isEmpty()) {
+                    return "No peers with name $exitNodeName found"
+                } else if (filteredPeers.size > 1) {
+                    return "Multiple peers with name $exitNodeName found"
+                } else if (!filteredPeers[0].isExitNode) {
+                    return "Peer with name $exitNodeName is not an exit node"
+                }
+
+                filteredPeers[0].StableID
+            }
+
+            val allowLanAccess = inputData.getBoolean(ALLOW_LAN_ACCESS, false)
+            val prefsOut = Ipn.MaskedPrefs()
+            prefsOut.ExitNodeID = exitNodeId
+            prefsOut.ExitNodeAllowLANAccess = allowLanAccess
+
+            val scope = CoroutineScope(Dispatchers.Default + Job())
+            var result: String? = null
+            Client(scope).editPrefs(prefsOut) {
+                result = if (it.isFailure) {
+                    it.exceptionOrNull()?.message
+                } else {
+                    null
+                }
+            }
+
+            scope.coroutineContext[Job]?.join()
+
+            return result
+        }
+
+        val result = runAndGetResult()
+
+        return if (result != null) {
+            val app = UninitializedApp.get()
+            val intent =
+                Intent(app, MainActivity::class.java).apply {
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                }
+            val pendingIntent: PendingIntent =
+                PendingIntent.getActivity(
+                    app, 1, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+
+            val notification = NotificationCompat.Builder(app, STATUS_CHANNEL_ID)
+                .setSmallIcon(R.drawable.ic_notification)
+                .setContentTitle("Use Exit Node Intent Failed")
+                .setContentText(result)
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                .setContentIntent(pendingIntent)
+                .build()
+
+            app.notifyStatus(notification)
+
+            Result.failure(Data.Builder().putString(ERROR_KEY, result).build())
+        } else {
+            Result.success()
+        }
+    }
+
+    companion object {
+        const val EXIT_NODE_NAME = "EXIT_NODE_NAME"
+        const val ALLOW_LAN_ACCESS = "ALLOW_LAN_ACCESS"
+        const val ERROR_KEY = "error"
+    }
+}

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -243,6 +243,15 @@
     <string name="welcome2">All connections are device-to-device, so we never see your data. We collect and use your email address and name, as well as your device name, OS version, and IP address in order to help you to connect your devices and manage your settings. We log when you are connected to your network.</string>
     <string name="scan_to_connect_to_your_tailnet">Scan this QR code to log in to your tailnet</string>
 
+    <!-- Strings for intent handling -->
+    <string name="vpn_is_not_ready_to_start">VPN is not ready to start</string>
+    <string name="tailscale_is_not_setup">Tailscale is not setup</string>
+    <string name="no_peers_found">No peers found</string>
+    <string name="no_peers_with_name_found">No peers with name %1$s found</string>
+    <string name="multiple_peers_with_name_found">Multiple peers with name %1$s found</string>
+    <string name="peer_with_name_is_not_an_exit_node">Peer with name %1$s is not an exit node</string>
+    <string name="use_exit_node_intent_failed">Use Exit Node Intent Failed</string>
+
     <!-- Strings for the IPNReceiver -->
     <string name="title_connection_failed">Tailscale Connection Failed</string>
     <string name="body_open_tailscale">Tap here to open Tailscale.</string>


### PR DESCRIPTION
Closes https://github.com/tailscale/tailscale/issues/8143. I map friendly labels from intent extras to tailscale node IDs, with empty string or not specifying the exitNode intent extra as the "no exit node" action. When an error is encountered, we will push a notification with a friendly message to the status notification channel. The tasker syntax I tested with locally is:

Action: `com.tailscale.ipn.USE_EXIT_NODE`
Package: `com.tailscale.ipn`
Class: `com.tailscale.ipn.IPNReceiver`
Target: Broadcast Receiver
Extra: `exitNode:exitNodeLabelOrEmpty`
Extra: `allowLanAccess:trueOrFalse`
