### PR TITLE
Fixes Android quick settings tile - issue #2646

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/IPNReceiver.java
+++ b/android/src/main/java/com/tailscale/ipn/IPNReceiver.java
@@ -12,14 +12,17 @@ import androidx.work.OneTimeWorkRequest;
 
 public class IPNReceiver extends BroadcastReceiver {
 
+    public static final String INTENT_CONNECT_VPN = "com.tailscale.ipn.CONNECT_VPN";
+    public static final String INTENT_DISCONNECT_VPN = "com.tailscale.ipn.DISCONNECT_VPN";
+
     @Override
     public void onReceive(Context context, Intent intent) {
         WorkManager workManager = WorkManager.getInstance(context);
 
         // On the relevant action, start the relevant worker, which can stay active for longer than this receiver can.
-        if (intent.getAction() == "com.tailscale.ipn.CONNECT_VPN") {
+        if (intent.getAction() == INTENT_CONNECT_VPN) {
             workManager.enqueue(new OneTimeWorkRequest.Builder(StartVPNWorker.class).build());
-        } else if (intent.getAction() == "com.tailscale.ipn.DISCONNECT_VPN") {
+        } else if (intent.getAction() == INTENT_DISCONNECT_VPN) {
             workManager.enqueue(new OneTimeWorkRequest.Builder(StopVPNWorker.class).build());
         }
     }

--- a/android/src/main/java/com/tailscale/ipn/QuickToggleService.java
+++ b/android/src/main/java/com/tailscale/ipn/QuickToggleService.java
@@ -7,6 +7,7 @@ package com.tailscale.ipn;
 import android.content.Context;
 import android.content.ComponentName;
 import android.content.Intent;
+import android.os.Build;
 import android.service.quicksettings.Tile;
 import android.service.quicksettings.TileService;
 
@@ -79,5 +80,14 @@ public class QuickToggleService extends TileService {
 		updateTile();
 	}
 
-	private static native void onTileClick();
+	private void onTileClick() {
+		boolean act;
+		synchronized (lock) {
+			act = active && ready;
+		}
+		Intent i = new Intent(act ? IPNReceiver.INTENT_DISCONNECT_VPN : IPNReceiver.INTENT_CONNECT_VPN);
+		i.setPackage(getPackageName());
+		i.setClass(getApplicationContext(), com.tailscale.ipn.IPNReceiver.class);
+		sendBroadcast(i);
+	}
 }

--- a/android/src/main/java/com/tailscale/ipn/QuickToggleService.java
+++ b/android/src/main/java/com/tailscale/ipn/QuickToggleService.java
@@ -5,14 +5,9 @@
 package com.tailscale.ipn;
 
 import android.content.Context;
-import android.content.ComponentName;
 import android.content.Intent;
-import android.os.Build;
 import android.service.quicksettings.Tile;
 import android.service.quicksettings.TileService;
-
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 public class QuickToggleService extends TileService {
 	// lock protects the static fields below it.

--- a/cmd/tailscale/callbacks.go
+++ b/cmd/tailscale/callbacks.go
@@ -126,11 +126,6 @@ func Java_com_tailscale_ipn_App_onConnectivityChanged(env *C.JNIEnv, cls C.jclas
 	onConnectivityChange <- connected == C.JNI_TRUE
 }
 
-//export Java_com_tailscale_ipn_QuickToggleService_onTileClick
-func Java_com_tailscale_ipn_QuickToggleService_onTileClick(env *C.JNIEnv, cls C.jclass) {
-	requestBackend(ToggleEvent{})
-}
-
 //export Java_com_tailscale_ipn_Peer_onActivityResult0
 func Java_com_tailscale_ipn_Peer_onActivityResult0(env *C.JNIEnv, cls C.jclass, act C.jobject, reqCode, resCode C.jint) {
 	switch reqCode {


### PR DESCRIPTION
Fix for Android quick settings tile - based on new intents `com.tailscale.ipn.CONNECT_VPN` and `com.tailscale.ipn.DISCONNECT_VPN` from https://github.com/tailscale/tailscale/issues/3547

![Screenshot_20231213_222936](https://github.com/tailscale/tailscale-android/assets/2743637/f24189c6-f682-4ae7-a30a-a3b7b96c7153)
![Screenshot_20231213_222922](https://github.com/tailscale/tailscale-android/assets/2743637/2dd4f8b5-29ff-4d48-a9a3-f6944995ae00)
