### PR TITLE
Record DNS search domains as well as nameservers.

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/App.java
+++ b/android/src/main/java/com/tailscale/ipn/App.java
@@ -115,6 +115,12 @@ public class App extends Application {
 				for (InetAddress ip : dnsList) {
 					sb.append(ip.getHostAddress()).append(" ");
 				}
+				String searchDomains = linkProperties.getDomains();
+				if (searchDomains != null) {
+					sb.append("\n");
+					sb.append(searchDomains);
+				}
+
 				dns.updateDNSFromNetwork(sb.toString());
 				onDnsConfigChanged();
 			}


### PR DESCRIPTION
We accidentally removed this in the big connectivity monitor fix.

Updates tailscale/tailscale#10107