### PR TITLE
Feature/last seen indicator

### DIFF
--- a/cmd/tailscale/ui.go
+++ b/cmd/tailscale/ui.go
@@ -1327,6 +1327,23 @@ func (ui *UI) layoutPeer(gtx layout.Context, sysIns system.Insets, p *UIPeer, us
 					l.Color = rgb(0x434343)
 					return l.Layout(gtx)
 				}),
+				layout.Rigid(func(gtx C) D {
+					return layout.Inset{Right: unit.Dp(4)}.Layout(gtx, func(gtx C) D {
+						isOnline := p.Peer.Online != nil && *p.Peer.Online
+						lastSeen := p.Peer.LastSeen
+						if isOnline {
+							l := material.Body2(ui.theme, "Last seen: Online")
+							l.Color = rgb(0x434343)
+							return l.Layout(gtx)
+						}
+						if lastSeen.IsZero() {
+							return D{}
+						}
+						l := material.Body2(ui.theme, lastSeen.Format("Last seen: Jan 2, 2006 15:04"))
+						l.Color = rgb(0x434343)
+						return l.Layout(gtx)
+					})
+				}),
 			)
 		})
 	})

--- a/cmd/tailscale/ui.go
+++ b/cmd/tailscale/ui.go
@@ -1332,7 +1332,7 @@ func (ui *UI) layoutPeer(gtx layout.Context, sysIns system.Insets, p *UIPeer, us
 						isOnline := p.Peer.Online != nil && *p.Peer.Online
 						lastSeen := p.Peer.LastSeen
 						if isOnline {
-							l := material.Body2(ui.theme, "Last seen: Online")
+							l := material.Body2(ui.theme, "Connected")
 							l.Color = rgb(0x434343)
 							return l.Layout(gtx)
 						}


### PR DESCRIPTION
I've added a new line to the Peer renderer to show the node last seen or online status.

![image](https://github.com/tailscale/tailscale-android/assets/23167933/44b2a94a-3127-46bd-ac11-3d1d42ea3331)
