### PR TITLE
cmd/tailscale/main: use localapi for generating bug report

### DIFF
--- a/cmd/localapiclient/localapiclient.go
+++ b/cmd/localapiclient/localapiclient.go
@@ -1,0 +1,102 @@
+package localapiclient
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+
+	"tailscale.com/ipn/localapi"
+)
+
+// Response represents the result of processing an http.Request.
+type Response struct {
+	headers              http.Header
+	status               int
+	bodyWriter           net.Conn
+	bodyReader           net.Conn
+	startWritingBody     chan interface{}
+	startWritingBodyOnce sync.Once
+}
+
+func (r *Response) Header() http.Header {
+	return r.headers
+}
+
+// Write writes the data to the response body and will send the data to Java.
+func (r *Response) Write(data []byte) (int, error) {
+	r.Flush()
+	if r.status == 0 {
+		r.WriteHeader(http.StatusOK)
+	}
+	return r.bodyWriter.Write(data)
+}
+
+func (r *Response) WriteHeader(statusCode int) {
+	r.status = statusCode
+}
+
+func (r *Response) Body() net.Conn {
+	return r.bodyReader
+}
+
+func (r *Response) StatusCode() int {
+	return r.status
+}
+
+func (r *Response) Flush() {
+	r.startWritingBodyOnce.Do(func() {
+		close(r.startWritingBody)
+	})
+}
+
+type LocalAPIClient struct {
+	h *localapi.Handler
+}
+
+func New(h *localapi.Handler) *LocalAPIClient {
+	return &LocalAPIClient{h: h}
+}
+
+// Call calls the given endpoint on the local API using the given HTTP method
+// optionally sending the given body. It returns a Response representing the
+// result of the call and an error if the call could not be completed or the
+// local API returned a status code in the 400 series or greater.
+// Note - Response includes a response body available from the Body method, it
+// is the caller's responsibility to close this.
+func (cl *LocalAPIClient) Call(ctx context.Context, method, endpoint string, body io.Reader) (*Response, error) {
+	req, err := http.NewRequestWithContext(ctx, method, "/localapi/v0/"+endpoint, body)
+	if err != nil {
+		return nil, fmt.Errorf("error creating new request for %s: %w", endpoint, err)
+	}
+	deadline, _ := ctx.Deadline()
+	pipeReader, pipeWriter := net.Pipe()
+	pipeReader.SetDeadline(deadline)
+	pipeWriter.SetDeadline(deadline)
+
+	resp := &Response{
+		headers:          http.Header{},
+		status:           http.StatusOK,
+		bodyReader:       pipeReader,
+		bodyWriter:       pipeWriter,
+		startWritingBody: make(chan interface{}),
+	}
+
+	go func() {
+		cl.h.ServeHTTP(resp, req)
+		resp.Flush()
+		pipeWriter.Close()
+	}()
+
+	select {
+	case <-resp.startWritingBody:
+		if resp.StatusCode() >= 400 {
+			return resp, fmt.Errorf("request failed with status code %d", resp.StatusCode())
+		}
+		return resp, nil
+	case <-ctx.Done():
+		return nil, fmt.Errorf("timeout for %s", endpoint)
+	}
+}

--- a/cmd/tailscale/backend.go
+++ b/cmd/tailscale/backend.go
@@ -48,7 +48,7 @@ type backend struct {
 	lastDNSCfg *dns.OSConfig
 	netMon     *netmon.Monitor
 
-	logIDPublic string
+	logIDPublic logid.PublicID
 	logger      *logtail.Logger
 
 	// avoidEmptyDNS controls whether to use fallback nameservers
@@ -150,7 +150,7 @@ func newBackend(dataDir string, jvm *jni.JVM, appCtx jni.Object, store *stateSto
 		return nil, fmt.Errorf("runBackend: NewUserspaceEngine: %v", err)
 	}
 	sys.Set(engine)
-	b.logIDPublic = logID.Public().String()
+	b.logIDPublic = logID.Public()
 	ns, err := netstack.Create(logf, sys.Tun.Get(), engine, sys.MagicSock.Get(), dialer, sys.DNSManager.Get(), sys.ProxyMapper())
 	if err != nil {
 		return nil, fmt.Errorf("netstack.Create: %w", err)

--- a/go.sum
+++ b/go.sum
@@ -311,6 +311,8 @@ github.com/nats-io/nats.go v1.9.1/go.mod h1:ZjDU1L/7fJ09jvUSRVBR2e7+RnLiiIQyqyzE
 github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
+github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
+github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
@@ -410,6 +412,8 @@ github.com/tailscale/web-client-prebuilt v0.0.0-20240208184856-443a64766f61 h1:G
 github.com/tailscale/web-client-prebuilt v0.0.0-20240208184856-443a64766f61/go.mod h1:agQPE6y6ldqCOui2gkIh7ZMztTkIQKH049tv8siLuNQ=
 github.com/tailscale/wireguard-go v0.0.0-20231121184858-cc193a0b3272 h1:zwsem4CaamMdC3tFoTpzrsUSMDPV0K6rhnQdF7kXekQ=
 github.com/tailscale/wireguard-go v0.0.0-20231121184858-cc193a0b3272/go.mod h1:BOm5fXUBFM+m9woLNBoxI9TaBXXhGNP50LX/TGIvGb4=
+github.com/tc-hib/winres v0.2.1 h1:YDE0FiP0VmtRaDn7+aaChp1KiF4owBiJa5l964l5ujA=
+github.com/tc-hib/winres v0.2.1/go.mod h1:C/JaNhH3KBvhNKVbvdlDWkbMDO9H4fKKDaN7/07SSuk=
 github.com/tcnksm/go-httpstat v0.2.0 h1:rP7T5e5U2HfmOBmZzGgGZjBQ5/GluWUylujl0tJ04I0=
 github.com/tcnksm/go-httpstat v0.2.0/go.mod h1:s3JVJFtQxtBEBC9dwcdTTXS9xFnM3SXAZwPG41aurT8=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=


### PR DESCRIPTION
-Create a custom http.ResponseWriter whose responses can be read and in the future, sent to Java/Kotlin via JNI
-Make http request and call localapi directly

The purpose of this change is to test out swapping an existing feature's implementation for the new pattern of using localapi. I added a global channel for the bug report in order to contain the scope of this change to just this. 

Updates #10992