### PR TITLE
cmd/tailscale/main: apply custom control server on first start

### DIFF
--- a/cmd/tailscale/main.go
+++ b/cmd/tailscale/main.go
@@ -1166,6 +1166,11 @@ func (a *App) processUIEvents(w *app.Window, events []UIEvent, act jni.Object, s
 			a.signOut()
 			requestBackend(e)
 		case ConnectEvent:
+			if srv, _ := a.store.ReadString(customLoginServerPrefKey, ""); srv != state.backend.Prefs.ControlURL {
+				requestBackend(SetLoginServerEvent{URL: srv})
+				// wait a moment for the backend to restart
+				<-time.After(200 * time.Millisecond)
+			}
 			requestBackend(e)
 		case RouteAllEvent:
 			requestBackend(e)


### PR DESCRIPTION
Currently the custom control server is not applied on start. To remedy this, check the stored preference and if they differ issue an event to switch to the correct backend server.