### PR TITLE
cmd/tailscale: do not show location based exit nodes in main view

### DIFF
--- a/cmd/tailscale/ui.go
+++ b/cmd/tailscale/ui.go
@@ -560,6 +560,12 @@ func (ui *UI) layout(gtx layout.Context, sysIns system.Insets, state *clientStat
 							ui.showCopied(gtx, a)
 						}
 					}
+
+					if p.Peer.Hostinfo.Location() != nil && p.Peer.IsWireGuardOnly {
+						// If the peer has location information set and is a wireguard
+						// only peer then it should not be displayed in the main list.
+						return D{}
+					}
 					return ui.layoutPeer(gtx, sysIns, p, userID, clk)
 				}
 			}


### PR DESCRIPTION
This change stops us from clogging up the main UI view with location based exit nodes, which can be in their hundreds. They will still appear in the exit node UI.
![Screenshot from 2024-02-07 16-34-42](https://github.com/tailscale/tailscale-android/assets/46385858/9debda3f-1f1b-4ed9-911a-ce400545c172)
![Screenshot from 2024-02-07 16-34-34](https://github.com/tailscale/tailscale-android/assets/46385858/634e8947-21f0-40aa-9e3d-fd651c2b8818)



Updates tailscale/tailscale#9438