### PR TITLE
cmd/tailscale: improve exit node menu for location based exit nodes

### DIFF
--- a/cmd/tailscale/ui.go
+++ b/cmd/tailscale/ui.go
@@ -1054,7 +1054,7 @@ func (ui *UI) layoutExitNodeDialog(gtx layout.Context, sysIns system.Insets, exi
 									Bottom: unit.Dp(16),
 								}.Layout(gtx, btn.Layout)
 							}
-							node := Peer{Label: "None", Online: true}
+							node := Peer{Label: "None", Online: true, Location: nil}
 							if idx >= 2 {
 								node = exits[idx-2]
 							}


### PR DESCRIPTION
This change provides minor improvements to the exit node menu when there are location based exit nodes present. It will ensure that non location based exit nodes are displayed at the top of the list, followed by a the best node for a country/city combination, and followed by all location based exit nodes.

Updates tailscale/tailscale#9421

![Screenshot from 2024-02-08 10-27-50](https://github.com/tailscale/tailscale-android/assets/46385858/0b01f676-382e-474b-9cc9-9fe458b852b1)
![Screenshot from 2024-02-08 10-30-25](https://github.com/tailscale/tailscale-android/assets/46385858/02061cc7-9bfe-4933-9bcf-26f323ed64bf)

