### PR TITLE
cmd/tailscale, tailscale/ipn: fix alway-on VPN

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/App.java
+++ b/android/src/main/java/com/tailscale/ipn/App.java
@@ -135,13 +135,13 @@ public class App extends Application {
 
 	public void startVPN() {
 		Intent intent = new Intent(this, IPNService.class);
-		intent.setAction(IPNService.ACTION_CONNECT);
+		intent.setAction(IPNService.ACTION_REQUEST_VPN);
 		startService(intent);
 	}
 
 	public void stopVPN() {
 		Intent intent = new Intent(this, IPNService.class);
-		intent.setAction(IPNService.ACTION_DISCONNECT);
+		intent.setAction(IPNService.ACTION_STOP_VPN);
 		startService(intent);
 	}
 

--- a/cmd/tailscale/callbacks.go
+++ b/cmd/tailscale/callbacks.go
@@ -24,9 +24,9 @@ var (
 	// onVPNRevoked is notified whenever the VPN service is revoked.
 	onVPNRevoked = make(chan struct{}, 1)
 
-	// onConnect receives global IPNService references when
+	// onVPNRequested receives global IPNService references when
 	// a VPN connection is requested.
-	onConnect = make(chan jni.Object)
+	onVPNRequested = make(chan jni.Object)
 	// onDisconnect receives global IPNService references when
 	// disconnecting.
 	onDisconnect = make(chan jni.Object)
@@ -90,14 +90,14 @@ func notifyVPNClosed() {
 	}
 }
 
-//export Java_com_tailscale_ipn_IPNService_connect
-func Java_com_tailscale_ipn_IPNService_connect(env *C.JNIEnv, this C.jobject) {
+//export Java_com_tailscale_ipn_IPNService_requestVPN
+func Java_com_tailscale_ipn_IPNService_requestVPN(env *C.JNIEnv, this C.jobject) {
 	jenv := (*jni.Env)(unsafe.Pointer(env))
-	onConnect <- jni.NewGlobalRef(jenv, jni.Object(this))
+	onVPNRequested <- jni.NewGlobalRef(jenv, jni.Object(this))
 }
 
-//export Java_com_tailscale_ipn_IPNService_directConnect
-func Java_com_tailscale_ipn_IPNService_directConnect(env *C.JNIEnv, this C.jobject) {
+//export Java_com_tailscale_ipn_IPNService_connect
+func Java_com_tailscale_ipn_IPNService_connect(env *C.JNIEnv, this C.jobject) {
 	requestBackend(ConnectEvent{Enable: true})
 }
 


### PR DESCRIPTION
-If a ConnectEvent is received before the first notification, (as happens when a connection is attempted due to Always-on after device reboot) create state.Prefs.
-Create an intent to start the VPN worker in the case of an always-on intent received on device reboot
-Rename onConnect channel to onVPNRequested, since this isn't doing the actual connecting

Fixes https://github.com/tailscale/tailscale/issues/2481