### PR TITLE
cmd/tailscale/main: restore persisted settings

### DIFF
--- a/cmd/tailscale/backend.go
+++ b/cmd/tailscale/backend.go
@@ -68,6 +68,8 @@ const (
 	logPrefKey               = "privatelogid"
 	loginMethodPrefKey       = "loginmethod"
 	customLoginServerPrefKey = "customloginserver"
+	exitNodePrefKey          = "exitnode"
+	exitAllowLANPrefKey      = "exitallowlan"
 )
 
 const (


### PR DESCRIPTION
When user signs in or starts the session, check and restore the following settings if set previously: 
- allow LAN access 
- use exit node
- use custom login server

Fixes tailscale/tailscale#10748