### PR TITLE
cmd/tailscale: pass nil TailFSForLocal to netstack.Create

### DIFF
--- a/cmd/tailscale/backend.go
+++ b/cmd/tailscale/backend.go
@@ -151,7 +151,7 @@ func newBackend(dataDir string, jvm *jni.JVM, appCtx jni.Object, store *stateSto
 	}
 	sys.Set(engine)
 	b.logIDPublic = logID.Public()
-	ns, err := netstack.Create(logf, sys.Tun.Get(), engine, sys.MagicSock.Get(), dialer, sys.DNSManager.Get(), sys.ProxyMapper())
+	ns, err := netstack.Create(logf, sys.Tun.Get(), engine, sys.MagicSock.Get(), dialer, sys.DNSManager.Get(), sys.ProxyMapper(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("netstack.Create: %w", err)
 	}


### PR DESCRIPTION
In the latest tailscale.com, netstack.Create has a new parameter that must be supplied.

Updates #cleanup