### PR TITLE
cmd/tailscale/ui: only show exit node options if relevant

### DIFF
--- a/cmd/tailscale/ui.go
+++ b/cmd/tailscale/ui.go
@@ -371,7 +371,7 @@ func (ui *UI) layout(gtx layout.Context, sysIns system.Insets, state *clientStat
 		}
 	}
 	if p := state.backend.Prefs; p != nil {
-		exitID = p.ExitNodeID
+		exitID = p.ExitNodeID()
 	}
 	if d := &ui.exitDialog; d.show {
 		if newID := tailcfg.StableNodeID(d.exits.Value); newID != exitID {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tailscale/tailscale-android
 
-go 1.22
+go 1.22.0
 
 require (
 	eliasnaur.com/font v0.0.0-20220124212145-832bb8fc08c3


### PR DESCRIPTION
-If exit node is being run, don't show an option to use an exit node
-If exit node is being used, don't show an option to run/stop running as an exit node