### PR TITLE
Restore persistent VPN status notification in Android 13+

### DIFF
--- a/android_legacy/src/main/AndroidManifest.xml
+++ b/android_legacy/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
 	<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28"/>
 	<uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
+	<uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
 	<!-- Disable input emulation on ChromeOS -->
 	<uses-feature android:name="android.hardware.type.pc" android:required="false"/>

--- a/android_legacy/src/main/java/com/tailscale/ipn/App.java
+++ b/android_legacy/src/main/java/com/tailscale/ipn/App.java
@@ -284,6 +284,17 @@ public class App extends Application {
 		return null;
 	}
 
+	void requestNotificationPermission(Activity act) {
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+			// We can send notifications without explicit notifications permission.
+			return;
+		}
+		if (ContextCompat.checkSelfPermission(act, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED) {
+			return;
+		}
+		act.requestPermissions(new String[]{Manifest.permission.POST_NOTIFICATIONS}, IPNActivity.NOTIFICATIONS_PERMISSION_RESULT);
+	}
+
 	void requestWriteStoragePermission(Activity act) {
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q || Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
 			// We can write files without permission.

--- a/android_legacy/src/main/java/com/tailscale/ipn/IPNActivity.java
+++ b/android_legacy/src/main/java/com/tailscale/ipn/IPNActivity.java
@@ -20,6 +20,7 @@ import org.gioui.GioView;
 
 public final class IPNActivity extends Activity {
 	final static int WRITE_STORAGE_RESULT = 1000;
+	final static int NOTIFICATIONS_PERMISSION_RESULT = 1001;
 
 	private GioView view;
 
@@ -97,6 +98,13 @@ public final class IPNActivity extends Activity {
 			if (grants.length > 0 && grants[0] == PackageManager.PERMISSION_GRANTED) {
 				App.onWriteStorageGranted();
 			}
+			break;
+		case NOTIFICATIONS_PERMISSION_RESULT:
+			// Start the VPN regardless of the notifications permission being granted.
+			// It's not a blocker for running the VPN.
+			App app = ((App)getApplicationContext());
+			app.startVPN();
+			break;
 		}
 	}
 

--- a/cmd/tailscale/main.go
+++ b/cmd/tailscale/main.go
@@ -1148,10 +1148,17 @@ func (a *App) runUI() error {
 			}
 		case <-onVPNPrepared:
 			if state.backend.State > ipn.Stopped {
-				if err := a.callVoidMethod(a.appCtx, "startVPN", "()V"); err != nil {
-					return err
-				}
-				if activity != 0 {
+				// If there isn't a foreground activity start the VPN right away.
+				if activity == 0 {
+					if err := a.callVoidMethod(a.appCtx, "startVPN", "()V"); err != nil {
+						return err
+					}
+				} else {
+					// Otherwise, check for notification permission and let the result
+					// of that start the VPN service.
+					if err := a.callVoidMethod(a.appCtx, "requestNotificationPermission", "(Landroid/app/Activity;)V", jni.Value(activity)); err != nil {
+						return err
+					}
 					if err := a.callVoidMethod(a.appCtx, "requestWriteStoragePermission", "(Landroid/app/Activity;)V", jni.Value(activity)); err != nil {
 						return err
 					}


### PR DESCRIPTION
This should fix https://github.com/tailscale/tailscale/issues/10104.

I recorded a screencast of this working on my emulator. I am happy to send it to someone at Tailscale privately, if needed.

From Android's docs:

> Android 13 (API level 33) and higher supports a [runtime permission](https://developer.android.com/guide/topics/permissions/overview#runtime) for sending [non-exempt](https://developer.android.com/develop/ui/views/notifications/notification-permission#exemptions) (including Foreground Services (FGS)) notifications from an app: [POST_NOTIFICATIONS](https://developer.android.com/reference/android/Manifest.permission#POST_NOTIFICATIONS). This change helps users focus on the notifications that are most important to them.

Ref: https://developer.android.com/develop/ui/views/notifications/notification-permission