### PR TITLE
*: introduce tool/go following our common pattern

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	golang.org/x/mobile v0.0.0-20240319015410-c58ccf4b0c87
 	golang.org/x/sys v0.18.0
 	inet.af/netaddr v0.0.0-20220617031823-097006376321
-	tailscale.com v1.61.0-pre.0.20240311120500-7429e8912acb
+	tailscale.com v1.63.0-pre.0.20240319225125-6da1dc84de57
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -666,5 +666,5 @@ sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 software.sslmate.com/src/go-pkcs12 v0.4.0 h1:H2g08FrTvSFKUj+D309j1DPfk5APnIdAQAB8aEykJ5k=
 software.sslmate.com/src/go-pkcs12 v0.4.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=
-tailscale.com v1.61.0-pre.0.20240311120500-7429e8912acb h1:XUkF0NkRcJ3gZupkOyZ4+NJ8t6scL+QuntLYP/iyeuo=
-tailscale.com v1.61.0-pre.0.20240311120500-7429e8912acb/go.mod h1:cC0b0vYCoSDOLufJX5J5zDUrvV3lYwOLqlt9NW8y4cY=
+tailscale.com v1.63.0-pre.0.20240319225125-6da1dc84de57 h1:AkU/jPJff3JoDr3gbM8Aut/GK7zriPTOYL7IY99YTXc=
+tailscale.com v1.63.0-pre.0.20240319225125-6da1dc84de57/go.mod h1:cC0b0vYCoSDOLufJX5J5zDUrvV3lYwOLqlt9NW8y4cY=

--- a/go.toolchain.rev
+++ b/go.toolchain.rev
@@ -1,0 +1,1 @@
+f86d7c8ef64a0f8a2516fc23652eee28abc8d8e0

--- a/tool/go
+++ b/tool/go
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Copyright (c) Tailscale Inc & AUTHORS
+# SPDX-License-Identifier: BSD-3-Clause
+
+set -eo pipefail
+
+if [[ "${CI:-}" == "true" && "${NOBASHDEBUG:-}" != "true" ]]; then
+    set -x
+fi
+
+# Allow TOOLCHAINDIR to be overridden, as a special case for the fdroid build
+if [[ -z "${TOOLCHAINDIR}" ]]; then
+    toolchain="$HOME/.cache/tailscale-go"
+
+    if [[ -d "$toolchain" ]]; then
+        # A toolchain exists, but is it recent enough to compile gocross? If not,
+        # wipe it out so that the next if block fetches a usable one.
+        want_go_minor=$(grep -E '^go ' "go.mod" | cut -f2 -d'.')
+        have_go_minor=""
+        if [[ -f "$toolchain/VERSION" ]]; then
+            have_go_minor=$(head -1 "$toolchain/VERSION" | cut -f2 -d'.')
+        fi
+        # Shortly before stable releases, we run release candidate
+        # toolchains, which have a non-numeric suffix on the version
+        # number. Remove the rc qualifier, we just care about the minor
+        # version.
+        have_go_minor="${have_go_minor%rc*}"
+        if [[ -z "$have_go_minor" || "$have_go_minor" -lt "$want_go_minor" ]]; then
+            rm -rf "$toolchain" "$toolchain.extracted"
+        fi
+    fi
+    if [[ ! -d "$toolchain" ]]; then
+        mkdir -p "$HOME/.cache"
+
+        read -r REV <go.toolchain.rev
+
+        case "$REV" in
+        /*)
+            toolchain="$REV"
+            ;;
+        *)
+            # This works for linux and darwin, which is sufficient
+            # (we do not build tailscale-go for other targets).
+            HOST_OS=$(uname -s | tr A-Z a-z)
+            HOST_ARCH="$(uname -m)"
+            if [[ "$HOST_ARCH" == "aarch64" ]]; then
+                # Go uses the name "arm64".
+                HOST_ARCH="arm64"
+            elif [[ "$HOST_ARCH" == "x86_64" ]]; then
+                # Go uses the name "amd64".
+                HOST_ARCH="amd64"
+            fi
+
+            rm -rf "$toolchain" "$toolchain.extracted"
+            curl -f -L -o "$toolchain.tar.gz" "https://github.com/tailscale/go/releases/download/build-${REV}/${HOST_OS}-${HOST_ARCH}.tar.gz"
+            mkdir -p "$toolchain"
+            (cd "$toolchain" && tar --strip-components=1 -xf "$toolchain.tar.gz")
+            echo "$REV" >"$toolchain.extracted"
+            rm -f "$toolchain.tar.gz"
+            ;;
+        esac
+    fi
+else
+    # fdroid supplies it's own toolchain, rather than using ours.
+    toolchain="${TOOLCHAINDIR}"
+fi
+
+exec "${toolchain}/bin/go" "$@"


### PR DESCRIPTION
- This tool/go does not currently invoke gocross, as there's more work to do in gocross to be fully compatible with gomobile.
- Use GOBIN to target the output destinations for gomobile and gobind.
- Remove the old toolchain targets from the Makefile.
- Use ~/.cache/tailscale-go, like the OSS repo does.
- Introduce go.toolchain.rev as we have in the OSS repo, and update it in the bumposs task.