### PR TITLE
android: add ExitNodeAllowLANAccess toggle in exit node picker

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/ui/model/Ipn.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/model/Ipn.kt
@@ -42,7 +42,7 @@ class Ipn {
       var LocalTCPPort: Int? = null,
       var IncomingFiles: List<PartialFile>? = null,
       var ClientVersion: Tailcfg.ClientVersion? = null,
-      var TailFSShares: Map<String, String>? = null,
+      var TailFSShares: List<String>? = null,
   )
 
   @Serializable

--- a/android/src/main/java/com/tailscale/ipn/ui/view/ExitNodePicker.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/ExitNodePicker.kt
@@ -109,6 +109,8 @@ fun ExitNodePicker(
                 })
           }
         }
+
+        item("allowLANAccessToggle") { SettingRow(model.allowLANAccessSetting) }
       }
     }
   }

--- a/android/src/main/java/com/tailscale/ipn/ui/view/MainView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/MainView.kt
@@ -210,7 +210,7 @@ fun SettingsButton(user: IpnLocal.LoginProfile?, action: () -> Unit) {
 fun StartingView() {
   // (jonathan) TODO: On iOS this is the game-of-life Tailscale animation.
   Column(
-      modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background),
+      modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.secondaryContainer),
       verticalArrangement = Arrangement.Center,
       horizontalAlignment = Alignment.CenterHorizontally) {
         Text(

--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/DNSSettingsViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/DNSSettingsViewModel.kt
@@ -43,10 +43,7 @@ class DNSSettingsViewModel() : IpnViewModel() {
           isOn = MutableStateFlow(Notifier.prefs.value?.CorpDNS),
           onToggle = {
             LoadingIndicator.start()
-            toggleCorpDNS {
-              LoadingIndicator.stop()
-              // (jonathan) TODO: Error handling
-            }
+            toggleCorpDNS { LoadingIndicator.stop() }
           })
 
   init {

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -124,5 +124,6 @@
     <string name="tailscale_is_not_running_this_device_is_using_the_system_dns_resolver">Tailscale is not running. This device is using the system\'s DNS resolver.</string>
     <string name="this_device_is_using_the_system_dns_resolver">This device is using the system DNS resolver.</string>
     <string name="not_using_tailscale_dns">Not Using Tailscale DNS</string>
+    <string name="allow_lan_access">Allow LAN Access</string>
 
 </resources>


### PR DESCRIPTION
Updates ENG-3011

Just like on iOS, we should show a switch at the bottom of the exit node picker to toggle the `ExitNodeAllowLANAccess` preference.