### PR TITLE
android/ui: add transfer ID to outgoing file transfers

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/App.kt
+++ b/android/src/main/java/com/tailscale/ipn/App.kt
@@ -47,6 +47,12 @@ import com.tailscale.ipn.ui.localapi.Client
 import com.tailscale.ipn.ui.localapi.Request
 import com.tailscale.ipn.ui.model.Ipn
 import com.tailscale.ipn.ui.notifier.Notifier
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import libtailscale.Libtailscale
 import java.io.File
 import java.io.IOException
 import java.net.InetAddress
@@ -54,15 +60,9 @@ import java.net.NetworkInterface
 import java.security.GeneralSecurityException
 import java.util.Locale
 import java.util.Objects
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
-import libtailscale.Libtailscale
 
 class App : Application(), libtailscale.AppContext {
-  private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+  val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
   companion object {
     const val STATUS_CHANNEL_ID = "tailscale-status"

--- a/android/src/main/java/com/tailscale/ipn/ui/model/FileTransfer.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/model/FileTransfer.kt
@@ -1,9 +1,0 @@
-// Copyright (c) Tailscale Inc & AUTHORS
-// SPDX-License-Identifier: BSD-3-Clause
-
-package com.tailscale.ipn.ui.model
-
-import android.net.Uri
-
-// Encapsulates a uri based file transfer for Taildrop.
-data class FileTransfer(val filename: String, val size: Long, val uri: Uri)

--- a/android/src/main/java/com/tailscale/ipn/ui/model/Ipn.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/model/Ipn.kt
@@ -3,7 +3,10 @@
 
 package com.tailscale.ipn.ui.model
 
+import android.net.Uri
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
+import java.util.UUID
 
 class Ipn {
 
@@ -158,16 +161,25 @@ class Ipn {
 
   @Serializable
   data class OutgoingFile(
+      val ID: String = "",
       val Name: String,
-      val PeerID: StableNodeID,
-      val Started: String,
+      val PeerID: StableNodeID = "",
+      val Started: String = "",
       val DeclaredSize: Long,
-      val Sent: Long,
+      val Sent: Long = 0L,
       val PartialPath: String? = null,
       var FinalPath: String? = null,
-      val Finished: Boolean,
-      val Succeeded: Boolean,
-  )
+      val Finished: Boolean = false,
+      val Succeeded: Boolean = false,
+  ) {
+    @Transient lateinit var uri: Uri // only used on client
+
+    fun prepare(peerId: StableNodeID): OutgoingFile {
+      val f = copy(ID = UUID.randomUUID().toString(), PeerID = peerId)
+      f.uri = uri
+      return f
+    }
+  }
 
   @Serializable data class FileTarget(var Node: Tailcfg.Node, var PeerAPIURL: String)
 }

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	golang.org/x/mobile v0.0.0-20240319015410-c58ccf4b0c87
 	golang.org/x/sys v0.18.0
 	inet.af/netaddr v0.0.0-20220617031823-097006376321
-	tailscale.com v1.63.0-pre.0.20240324181545-f78928191539
+	tailscale.com v1.63.0-pre.0.20240326143037-34ae89e4972c
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -666,5 +666,5 @@ sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 software.sslmate.com/src/go-pkcs12 v0.4.0 h1:H2g08FrTvSFKUj+D309j1DPfk5APnIdAQAB8aEykJ5k=
 software.sslmate.com/src/go-pkcs12 v0.4.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=
-tailscale.com v1.63.0-pre.0.20240324181545-f78928191539 h1:DBpvudmMiWINWePS9RdY+dST7xOideFf26TSgqsu2rQ=
-tailscale.com v1.63.0-pre.0.20240324181545-f78928191539/go.mod h1:cC0b0vYCoSDOLufJX5J5zDUrvV3lYwOLqlt9NW8y4cY=
+tailscale.com v1.63.0-pre.0.20240326143037-34ae89e4972c h1:j7pSWQa+9OdNavdMVq0ZN7RDQ7CZDIxzTveKSeZ7I0c=
+tailscale.com v1.63.0-pre.0.20240326143037-34ae89e4972c/go.mod h1:cC0b0vYCoSDOLufJX5J5zDUrvV3lYwOLqlt9NW8y4cY=


### PR DESCRIPTION
Helps track status of transfers.

Updates #ENG-2868

I tested that I can initiate multiple concurrent transfers to the same peer. The status tracking correctly tracks status for the last initiated transfer, and all prior transfers still succeed (though their status is not tracked).