### PR TITLE
android/mdm: enforce MDM settings in UI items

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/mdm/MDMSettingsDefinitions.kt
+++ b/android/src/main/java/com/tailscale/ipn/mdm/MDMSettingsDefinitions.kt
@@ -53,8 +53,8 @@ enum class ShowHideValue(val value: String) {
   Hide("hide")
 }
 
-enum class NetworkDevices(val value: String) {
-  currentUser("current-user"),
-  otherUsers("other-users"),
-  taggedDevices("tagged-devices"),
+enum class HiddenNetworkDevices(val value: String) {
+  CurrentUser("current-user"),
+  OtherUsers("other-users"),
+  TaggedDevices("tagged-devices"),
 }

--- a/android/src/main/java/com/tailscale/ipn/ui/view/ExitNodePicker.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/ExitNodePicker.kt
@@ -21,6 +21,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.tailscale.ipn.R
+import com.tailscale.ipn.mdm.ShowHideSetting
+import com.tailscale.ipn.mdm.ShowHideValue
 import com.tailscale.ipn.ui.util.Lists
 import com.tailscale.ipn.ui.util.LoadingIndicator
 import com.tailscale.ipn.ui.util.clickableOrGrayedOut
@@ -28,6 +30,7 @@ import com.tailscale.ipn.ui.util.itemsWithDividers
 import com.tailscale.ipn.ui.viewModel.ExitNodePickerNav
 import com.tailscale.ipn.ui.viewModel.ExitNodePickerViewModel
 import com.tailscale.ipn.ui.viewModel.ExitNodePickerViewModelFactory
+import com.tailscale.ipn.ui.viewModel.IpnViewModel
 import com.tailscale.ipn.ui.viewModel.selected
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -45,9 +48,11 @@ fun ExitNodePicker(
       val anyActive = model.anyActive.collectAsState()
 
       LazyColumn(modifier = Modifier.padding(innerPadding)) {
-        item(key = "runExitNode") {
-          RunAsExitNodeItem(nav = nav, viewModel = model)
-          Lists.SectionDivider()
+        if (IpnViewModel.mdmSettings.value.get(ShowHideSetting.RunExitNode) == ShowHideValue.Show) {
+          item(key = "runExitNode") {
+            RunAsExitNodeItem(nav = nav, viewModel = model)
+            Lists.SectionDivider()
+          }
         }
 
         item(key = "none") {

--- a/android/src/main/java/com/tailscale/ipn/ui/view/MainView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/MainView.kt
@@ -50,6 +50,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.tailscale.ipn.R
+import com.tailscale.ipn.mdm.ShowHideSetting
+import com.tailscale.ipn.mdm.ShowHideValue
 import com.tailscale.ipn.ui.model.Ipn
 import com.tailscale.ipn.ui.model.IpnLocal
 import com.tailscale.ipn.ui.model.StableNodeID
@@ -59,6 +61,7 @@ import com.tailscale.ipn.ui.util.LoadingIndicator
 import com.tailscale.ipn.ui.util.PeerSet
 import com.tailscale.ipn.ui.util.flag
 import com.tailscale.ipn.ui.util.itemsWithDividers
+import com.tailscale.ipn.ui.viewModel.IpnViewModel
 import com.tailscale.ipn.ui.viewModel.MainViewModel
 import kotlinx.coroutines.flow.StateFlow
 
@@ -107,15 +110,17 @@ fun MainView(navigation: MainViewNavigation, viewModel: MainViewModel = viewMode
 
             when (state.value) {
               Ipn.State.Running -> {
-
+                val mdmSettings = IpnViewModel.mdmSettings.collectAsState().value
                 val selfPeerId = viewModel.selfPeerId.collectAsState(initial = "")
-                Row(
-                    modifier =
-                        Modifier.background(MaterialTheme.colorScheme.secondaryContainer)
-                            .padding(top = 10.dp, bottom = 20.dp)) {
-                      ExitNodeStatus(
-                          navAction = navigation.onNavigateToExitNodes, viewModel = viewModel)
-                    }
+                if (mdmSettings.get(ShowHideSetting.ExitNodesPicker) != ShowHideValue.Hide) {
+                  Row(
+                      modifier =
+                          Modifier.background(MaterialTheme.colorScheme.secondaryContainer)
+                              .padding(top = 10.dp, bottom = 20.dp)) {
+                        ExitNodeStatus(
+                            navAction = navigation.onNavigateToExitNodes, viewModel = viewModel)
+                      }
+                }
                 PeerList(
                     searchTerm = viewModel.searchTerm,
                     state = viewModel.ipnState,

--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/DNSSettingsViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/DNSSettingsViewModel.kt
@@ -10,6 +10,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.tailscale.ipn.R
+import com.tailscale.ipn.mdm.AlwaysNeverUserDecidesSetting
+import com.tailscale.ipn.mdm.AlwaysNeverUserDecidesValue
 import com.tailscale.ipn.ui.localapi.Client
 import com.tailscale.ipn.ui.model.Ipn
 import com.tailscale.ipn.ui.model.Tailcfg
@@ -41,6 +43,11 @@ class DNSSettingsViewModel() : IpnViewModel() {
           R.string.use_ts_dns,
           SettingType.SWITCH,
           isOn = MutableStateFlow(Notifier.prefs.value?.CorpDNS),
+          enabled =
+              MutableStateFlow(
+                  IpnViewModel.mdmSettings.value.get(
+                      AlwaysNeverUserDecidesSetting.UseTailscaleDNSSettings) ==
+                      AlwaysNeverUserDecidesValue.UserDecides),
           onToggle = {
             LoadingIndicator.start()
             toggleCorpDNS { LoadingIndicator.stop() }

--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/ExitNodePickerViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/ExitNodePickerViewModel.kt
@@ -7,6 +7,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.tailscale.ipn.R
+import com.tailscale.ipn.mdm.AlwaysNeverUserDecidesSetting
+import com.tailscale.ipn.mdm.AlwaysNeverUserDecidesValue
 import com.tailscale.ipn.ui.localapi.Client
 import com.tailscale.ipn.ui.model.Ipn
 import com.tailscale.ipn.ui.model.StableNodeID
@@ -62,7 +64,11 @@ class ExitNodePickerViewModel(private val nav: ExitNodePickerNav) : IpnViewModel
           R.string.allow_lan_access,
           SettingType.SWITCH,
           isOn = MutableStateFlow(Notifier.prefs.value?.ExitNodeAllowLANAccess),
-          enabled = MutableStateFlow(true),
+          enabled =
+              MutableStateFlow(
+                  IpnViewModel.mdmSettings.value.get(
+                      AlwaysNeverUserDecidesSetting.ExitNodeAllowLANAccess) ==
+                      AlwaysNeverUserDecidesValue.UserDecides),
           onToggle = {
             LoadingIndicator.start()
             toggleAllowLANAccess { LoadingIndicator.stop() }

--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/IpnViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/IpnViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.tailscale.ipn.App
 import com.tailscale.ipn.IPNReceiver
+import com.tailscale.ipn.mdm.BooleanSetting
 import com.tailscale.ipn.mdm.MDMSettings
 import com.tailscale.ipn.ui.localapi.Client
 import com.tailscale.ipn.ui.model.Ipn
@@ -95,6 +96,10 @@ open class IpnViewModel : ViewModel() {
 
   fun stopVPN() {
     val context = App.getApplication().applicationContext
+    if (mdmSettings.value.get(BooleanSetting.ForceEnabled)) {
+      Log.d(TAG, "Not stopping VPN due to ForceEnabled MDM setting.")
+      return
+    }
     val intent = Intent(context, IPNReceiver::class.java)
     intent.action = IPNReceiver.INTENT_DISCONNECT_VPN
     context.sendBroadcast(intent)

--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/SettingsViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/SettingsViewModel.kt
@@ -11,7 +11,11 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.tailscale.ipn.BuildConfig
 import com.tailscale.ipn.R
+import com.tailscale.ipn.mdm.AlwaysNeverUserDecidesSetting
+import com.tailscale.ipn.mdm.AlwaysNeverUserDecidesValue
 import com.tailscale.ipn.mdm.MDMSettings
+import com.tailscale.ipn.mdm.ShowHideSetting
+import com.tailscale.ipn.mdm.ShowHideValue
 import com.tailscale.ipn.mdm.StringSetting
 import com.tailscale.ipn.ui.notifier.Notifier
 import com.tailscale.ipn.ui.util.set
@@ -119,12 +123,20 @@ class SettingsViewModel(val navigation: SettingsNav) : IpnViewModel() {
               titleRes = R.string.dns_settings,
               SettingType.NAV,
               onClick = { navigation.onNavigateToDNSSettings() },
-              enabled = MutableStateFlow(true)),
+              enabled =
+                  MutableStateFlow(
+                      IpnViewModel.mdmSettings.value.get(
+                          AlwaysNeverUserDecidesSetting.UseTailscaleDNSSettings) ==
+                          AlwaysNeverUserDecidesValue.UserDecides)),
           Setting(
-              titleRes = R.string.tailnet_lock,
-              SettingType.NAV,
-              onClick = { navigation.onNavigateToTailnetLock() },
-              enabled = MutableStateFlow(true)),
+                  titleRes = R.string.tailnet_lock,
+                  SettingType.NAV,
+                  onClick = { navigation.onNavigateToTailnetLock() },
+                  enabled = MutableStateFlow(true))
+              .takeIf {
+                IpnViewModel.mdmSettings.value.get(ShowHideSetting.ManageTailnetLock) ==
+                    ShowHideValue.Show
+              },
           Setting(
               titleRes = R.string.about,
               SettingType.NAV,


### PR DESCRIPTION
Fixes ENG-2851

Uses our MDM settings in any place where we are drawing UI that should be hidden/disabled depending on the selected system policy value.

The ForceEnabled implementation lacks a UI component to warn the user when disablement is not allowed, but we can take care of that at a later time.