### PR TITLE
android/taildrop: support direct mode for incoming taildrop

### DIFF
--- a/libtailscale/callbacks.go
+++ b/libtailscale/callbacks.go
@@ -26,61 +26,13 @@ var (
 	// onGoogleToken receives google ID tokens.
 	onGoogleToken = make(chan string)
 
-	// onWriteStorageGranted is notified when we are granted WRITE_STORAGE_PERMISSION.
-	onWriteStorageGranted = make(chan struct{}, 1)
-
 	// onDNSConfigChanged is notified when the network changes and the DNS config needs to be updated.
 	onDNSConfigChanged = make(chan struct{}, 1)
 )
 
-func OnShareIntent(nfiles int32, types []int32, mimes []string, items []string, names []string, sizes []int) {
-	// TODO(oxtoacart): actually implement this
-	// const (
-	// 	typeNone   = 0
-	// 	typeInline = 1
-	// 	typeURI    = 2
-	// )
-	// jenv := (*jni.Env)(unsafe.Pointer(env))
-	// var files []File
-	// for i := 0; i < int(nfiles); i++ {
-	// 	f := File{
-	// 		Type:     FileType(types[i]),
-	// 		MIMEType: mimes[i],
-	// 		Name:     names[i],
-	// 	}
-	// 	if f.Name == "" {
-	// 		f.Name = "file.bin"
-	// 	}
-	// 	switch f.Type {
-	// 	case FileTypeText:
-	// 		f.Text = items[i]
-	// 		f.Size = int64(len(f.Text))
-	// 	case FileTypeURI:
-	// 		f.URI = items[i]
-	// 		f.Size = sizes[i]
-	// 	default:
-	// 		panic("unknown file type")
-	// 	}
-	// 	files = append(files, f)
-	// }
-	// select {
-	// case <-onFileShare:
-	// default:
-	// }
-	// onFileShare <- files
-}
-
 func OnDnsConfigChanged() {
 	select {
 	case onDNSConfigChanged <- struct{}{}:
-	default:
-	}
-}
-
-//export Java_com_tailscale_ipn_App_onWriteStorageGranted
-func OnWriteStorageGranted() {
-	select {
-	case onWriteStorageGranted <- struct{}{}:
 	default:
 	}
 }

--- a/libtailscale/interfaces.go
+++ b/libtailscale/interfaces.go
@@ -7,8 +7,8 @@ import _ "golang.org/x/mobile/bind"
 
 // Start starts the application, storing state in the given dataDir and using
 // the given appCtx.
-func Start(dataDir string, appCtx AppContext) Application {
-	return start(dataDir, appCtx)
+func Start(dataDir, directFileRoot string, appCtx AppContext) Application {
+	return start(dataDir, directFileRoot, appCtx)
 }
 
 // AppContext provides a context within which the Application is running. This

--- a/libtailscale/tailscale.go
+++ b/libtailscale/tailscale.go
@@ -30,10 +30,11 @@ const (
 	customLoginServerPrefKey = "customloginserver"
 )
 
-func newApp(dataDir string, appCtx AppContext) Application {
+func newApp(dataDir, directFileRoot string, appCtx AppContext) Application {
 	a := &App{
-		dataDir: dataDir,
-		appCtx:  appCtx,
+		directFileRoot: directFileRoot,
+		dataDir:        dataDir,
+		appCtx:         appCtx,
 	}
 	a.ready.Add(1)
 


### PR DESCRIPTION
Updates tailscale/corp#18202

Implements direct mode support for incoming taildrop files.  None of the localAPI endpoints are implemented here but this will get taildrop files to the right places.