### PR TITLE
android/ui: speed up loading of SettingsView

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -75,6 +75,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
     // Compose dependencies.
     def composeBom = platform('androidx.compose:compose-bom:2023.06.01')

--- a/android/src/main/java/com/tailscale/ipn/MainActivity.kt
+++ b/android/src/main/java/com/tailscale/ipn/MainActivity.kt
@@ -27,7 +27,6 @@ import com.tailscale.ipn.Peer.RequestCodes
 import com.tailscale.ipn.mdm.MDMSettings
 import com.tailscale.ipn.ui.notifier.Notifier
 import com.tailscale.ipn.ui.theme.AppTheme
-import com.tailscale.ipn.ui.util.set
 import com.tailscale.ipn.ui.view.AboutView
 import com.tailscale.ipn.ui.view.BackNavigation
 import com.tailscale.ipn.ui.view.BugReportView
@@ -47,7 +46,6 @@ import com.tailscale.ipn.ui.view.SettingsView
 import com.tailscale.ipn.ui.view.TailnetLockSetupView
 import com.tailscale.ipn.ui.view.UserSwitcherView
 import com.tailscale.ipn.ui.viewModel.ExitNodePickerNav
-import com.tailscale.ipn.ui.viewModel.IpnViewModel
 import com.tailscale.ipn.ui.viewModel.SettingsNav
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -177,7 +175,9 @@ class MainActivity : ComponentActivity() {
     super.onResume()
     val restrictionsManager =
         this.getSystemService(Context.RESTRICTIONS_SERVICE) as RestrictionsManager
-    IpnViewModel.mdmSettings.set(MDMSettings(restrictionsManager))
+    lifecycleScope.launch(Dispatchers.IO) {
+      MDMSettings.update(App.getApplication(), restrictionsManager)
+    }
   }
 
   override fun onStart() {
@@ -196,7 +196,9 @@ class MainActivity : ComponentActivity() {
     super.onStop()
     val restrictionsManager =
         this.getSystemService(Context.RESTRICTIONS_SERVICE) as RestrictionsManager
-    IpnViewModel.mdmSettings.set(MDMSettings(restrictionsManager))
+    lifecycleScope.launch(Dispatchers.IO) {
+      MDMSettings.update(App.getApplication(), restrictionsManager)
+    }
   }
 
   private fun requestVpnPermission() {

--- a/android/src/main/java/com/tailscale/ipn/mdm/MDMSettings.kt
+++ b/android/src/main/java/com/tailscale/ipn/mdm/MDMSettings.kt
@@ -5,65 +5,60 @@ package com.tailscale.ipn.mdm
 
 import android.content.RestrictionsManager
 import com.tailscale.ipn.App
+import kotlin.reflect.KVisibility
+import kotlin.reflect.full.declaredMemberProperties
+import kotlin.reflect.full.isSubclassOf
+import kotlin.reflect.jvm.jvmErasure
 
-class MDMSettings(private val restrictionsManager: RestrictionsManager? = null) {
-  fun get(setting: BooleanSetting): Boolean {
-    restrictionsManager?.let {
-      if (it.applicationRestrictions.containsKey(setting.key)) {
-        return it.applicationRestrictions.getBoolean(setting.key)
-      }
-    }
-    return App.getApplication().getEncryptedPrefs().getBoolean(setting.key, false)
+object MDMSettings {
+  val forceEnabled = BooleanMDMSetting("ForceEnabled", "Force Enabled Connection Toggle")
+
+  val exitNodeID = StringMDMSetting("ExitNodeID", "Forced Exit Node: Stable ID")
+  val keyExpirationNotice = StringMDMSetting("KeyExpirationNotice", "Key Expiration Notice Period")
+  val loginURL = StringMDMSetting("LoginURL", "Custom control server URL")
+  val managedByCaption = StringMDMSetting("ManagedByCaption", "Managed By - Caption")
+  val managedByOrganizationName =
+      StringMDMSetting("ManagedByOrganizationName", "Managed By - Organization Name")
+  val managedByURL = StringMDMSetting("ManagedByURL", "Managed By - Support URL")
+  val tailnet = StringMDMSetting("Tailnet", "Recommended/Required Tailnet Name")
+
+  val hiddenNetworkDevices =
+      StringArrayListMDMSetting("HiddenNetworkDevices", "Hidden Network Device Categories")
+
+  val allowIncomingConnections =
+      AlwaysNeverUserDecidesMDMSetting("AllowIncomingConnections", "Allow Incoming Connections")
+  val detectThirdPartyAppConflicts =
+      AlwaysNeverUserDecidesMDMSetting(
+          "DetectThirdPartyAppConflicts", "Detect potentially problematic third-party apps")
+  val exitNodeAllowLANAccess =
+      AlwaysNeverUserDecidesMDMSetting(
+          "ExitNodeAllowLANAccess", "Allow LAN Access when using an exit node")
+  val postureChecking =
+      AlwaysNeverUserDecidesMDMSetting("PostureChecking", "Enable Posture Checking")
+  val useTailscaleDNSSettings =
+      AlwaysNeverUserDecidesMDMSetting("UseTailscaleDNSSettings", "Use Tailscale DNS Settings")
+  val useTailscaleSubnets =
+      AlwaysNeverUserDecidesMDMSetting("UseTailscaleSubnets", "Use Tailscale Subnets")
+
+  val exitNodesPicker = ShowHideMDMSetting("ExitNodesPicker", "Exit Nodes Picker")
+  val manageTailnetLock = ShowHideMDMSetting("ManageTailnetLock", "“Manage Tailnet lock” menu item")
+  val resetToDefaults = ShowHideMDMSetting("ResetToDefaults", "“Reset to Defaults” menu item")
+  val runExitNode = ShowHideMDMSetting("RunExitNode", "Run as Exit Node")
+  val testMenu = ShowHideMDMSetting("TestMenu", "Show Debug Menu")
+  val updateMenu = ShowHideMDMSetting("UpdateMenu", "“Update Available” menu item")
+
+  val allSettings by lazy {
+    MDMSettings::class
+        .declaredMemberProperties
+        .filter {
+          it.visibility == KVisibility.PUBLIC &&
+              it.returnType.jvmErasure.isSubclassOf(MDMSetting::class)
+        }
+        .map { it.call(MDMSettings) as MDMSetting<*> }
   }
 
-  fun get(setting: StringSetting): String? {
-    return restrictionsManager?.applicationRestrictions?.getString(setting.key)
-        ?: App.getApplication().getEncryptedPrefs().getString(setting.key, null)
-  }
-
-  fun get(setting: AlwaysNeverUserDecidesSetting): AlwaysNeverUserDecidesValue {
-    val storedString: String =
-        restrictionsManager?.applicationRestrictions?.getString(setting.key)
-            ?: App.getApplication().getEncryptedPrefs().getString(setting.key, null)
-            ?: "user-decides"
-    return when (storedString) {
-      "always" -> {
-        AlwaysNeverUserDecidesValue.Always
-      }
-      "never" -> {
-        AlwaysNeverUserDecidesValue.Never
-      }
-      else -> {
-        AlwaysNeverUserDecidesValue.UserDecides
-      }
-    }
-  }
-
-  fun get(setting: ShowHideSetting): ShowHideValue {
-    val storedString: String =
-        restrictionsManager?.applicationRestrictions?.getString(setting.key)
-            ?: App.getApplication().getEncryptedPrefs().getString(setting.key, null)
-            ?: "show"
-    return when (storedString) {
-      "hide" -> {
-        ShowHideValue.Hide
-      }
-      else -> {
-        ShowHideValue.Show
-      }
-    }
-  }
-
-  fun get(setting: StringArraySetting): Array<String>? {
-    restrictionsManager?.let {
-      if (it.applicationRestrictions.containsKey(setting.key)) {
-        return it.applicationRestrictions.getStringArray(setting.key)
-      }
-    }
-    return App.getApplication()
-            .getEncryptedPrefs()
-        .getStringSet(setting.key, HashSet<String>())
-        ?.toTypedArray()
-        ?.sortedArray()
+  fun update(app: App, restrictionsManager: RestrictionsManager?) {
+    val bundle = restrictionsManager?.applicationRestrictions
+    allSettings.forEach { it.setFrom(bundle, app) }
   }
 }

--- a/android/src/main/java/com/tailscale/ipn/ui/view/MDMSettingsDebugView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/MDMSettingsDebugView.kt
@@ -17,11 +17,8 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.tailscale.ipn.R
-import com.tailscale.ipn.mdm.AlwaysNeverUserDecidesSetting
-import com.tailscale.ipn.mdm.BooleanSetting
-import com.tailscale.ipn.mdm.ShowHideSetting
-import com.tailscale.ipn.mdm.StringArraySetting
-import com.tailscale.ipn.mdm.StringSetting
+import com.tailscale.ipn.mdm.MDMSetting
+import com.tailscale.ipn.mdm.MDMSettings
 import com.tailscale.ipn.ui.util.itemsWithDividers
 import com.tailscale.ipn.ui.viewModel.IpnViewModel
 
@@ -30,65 +27,30 @@ import com.tailscale.ipn.ui.viewModel.IpnViewModel
 fun MDMSettingsDebugView(nav: BackNavigation, model: IpnViewModel = viewModel()) {
   Scaffold(topBar = { Header(R.string.current_mdm_settings, onBack = nav.onBack) }) { innerPadding
     ->
-    val mdmSettings = IpnViewModel.mdmSettings.collectAsState().value
     LazyColumn(modifier = Modifier.padding(innerPadding)) {
-      itemsWithDividers(enumValues<BooleanSetting>(), key = { it.key }) { booleanSetting ->
-        MDMSettingView(
-            title = booleanSetting.localizedTitle,
-            caption = booleanSetting.key,
-            valueDescription = mdmSettings.get(booleanSetting).toString())
-      }
-
-      itemsWithDividers(enumValues<StringSetting>(), key = { it.key }, forceLeading = true) {
-          stringSetting ->
-        MDMSettingView(
-            title = stringSetting.localizedTitle,
-            caption = stringSetting.key,
-            valueDescription = mdmSettings.get(stringSetting).toString())
-      }
-
-      itemsWithDividers(enumValues<ShowHideSetting>(), key = { it.key }, forceLeading = true) {
-          showHideSetting ->
-        MDMSettingView(
-            title = showHideSetting.localizedTitle,
-            caption = showHideSetting.key,
-            valueDescription = mdmSettings.get(showHideSetting).toString())
-      }
-
-      itemsWithDividers(
-          enumValues<AlwaysNeverUserDecidesSetting>(), key = { it.key }, forceLeading = true) {
-              anuSetting ->
-            MDMSettingView(
-                title = anuSetting.localizedTitle,
-                caption = anuSetting.key,
-                valueDescription = mdmSettings.get(anuSetting).toString())
-          }
-
-      itemsWithDividers(enumValues<StringArraySetting>(), key = { it.key }, forceLeading = true) {
-          stringArraySetting ->
-        MDMSettingView(
-            title = stringArraySetting.localizedTitle,
-            caption = stringArraySetting.key,
-            valueDescription = mdmSettings.get(stringArraySetting).toString())
+      itemsWithDividers(MDMSettings.allSettings.sortedBy { "${it::class.java.name}|${it.key}" }) {
+          setting ->
+        MDMSettingView(setting)
       }
     }
   }
 }
 
 @Composable
-fun MDMSettingView(title: String, caption: String, valueDescription: String) {
+fun MDMSettingView(setting: MDMSetting<*>) {
+  val value = setting.flow.collectAsState().value
   ListItem(
-      headlineContent = { Text(title, maxLines = 3) },
+      headlineContent = { Text(setting.localizedTitle, maxLines = 3) },
       supportingContent = {
         Text(
-            caption,
+            setting.key,
             fontSize = MaterialTheme.typography.labelSmall.fontSize,
             color = MaterialTheme.colorScheme.tertiary,
             fontFamily = FontFamily.Monospace)
       },
       trailingContent = {
         Text(
-            valueDescription,
+            value.toString(),
             color = MaterialTheme.colorScheme.secondary,
             fontFamily = FontFamily.Monospace,
             maxLines = 1,

--- a/android/src/main/java/com/tailscale/ipn/ui/view/ManagedByView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/ManagedByView.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.tailscale.ipn.R
-import com.tailscale.ipn.mdm.StringSetting
+import com.tailscale.ipn.mdm.MDMSettings
 import com.tailscale.ipn.ui.viewModel.IpnViewModel
 
 @Composable
@@ -28,18 +28,19 @@ fun ManagedByView(nav: BackNavigation, model: IpnViewModel = viewModel()) {
             Arrangement.spacedBy(space = 20.dp, alignment = Alignment.CenterVertically),
         horizontalAlignment = Alignment.Start,
         modifier = Modifier.fillMaxWidth().safeContentPadding()) {
-          val mdmSettings = IpnViewModel.mdmSettings.collectAsState().value
-          mdmSettings.get(StringSetting.ManagedByOrganizationName)?.let {
+          val managedByOrganization =
+              MDMSettings.managedByOrganizationName.flow.collectAsState().value
+          val managedByCaption = MDMSettings.managedByCaption.flow.collectAsState().value
+          val managedByURL = MDMSettings.managedByURL.flow.collectAsState().value
+          managedByOrganization?.let {
             Text(stringResource(R.string.managed_by_explainer_orgName, it))
           } ?: run { Text(stringResource(R.string.managed_by_explainer)) }
-          mdmSettings.get(StringSetting.ManagedByCaption)?.let {
+          managedByCaption?.let {
             if (it.isNotEmpty()) {
               Text(it)
             }
           }
-          mdmSettings.get(StringSetting.ManagedByURL)?.let {
-            OpenURLButton(stringResource(R.string.open_support), it)
-          }
+          managedByURL?.let { OpenURLButton(stringResource(R.string.open_support), it) }
         }
   }
 }

--- a/android/src/main/java/com/tailscale/ipn/ui/view/SettingsView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/SettingsView.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
@@ -26,11 +25,11 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.tailscale.ipn.BuildConfig
 import com.tailscale.ipn.R
 import com.tailscale.ipn.ui.Links
 import com.tailscale.ipn.ui.theme.ts_color_dark_desctrutive_text
 import com.tailscale.ipn.ui.util.Lists
-import com.tailscale.ipn.ui.util.itemsWithDividers
 import com.tailscale.ipn.ui.viewModel.Setting
 import com.tailscale.ipn.ui.viewModel.SettingType
 import com.tailscale.ipn.ui.viewModel.SettingsNav
@@ -45,30 +44,44 @@ fun SettingsView(
   val handler = LocalUriHandler.current
   val user = viewModel.loggedInUser.collectAsState().value
   val isAdmin = viewModel.isAdmin.collectAsState().value
-  val settingsBundles = viewModel.settings.collectAsState().value
+  val managedBy = viewModel.managedBy.collectAsState().value
 
   Scaffold(
       topBar = { Header(title = R.string.settings_title, onBack = settingsNav.onBackPressed) }) {
           innerPadding ->
-        LazyColumn(modifier = Modifier.padding(innerPadding)) {
-          item {
-            UserView(
-                profile = user,
-                actionState = UserActionState.NAV,
-                onClick = viewModel.navigation.onNavigateToUserSwitcher)
-          }
+        Column(modifier = Modifier.padding(innerPadding)) {
+          UserView(
+              profile = user,
+              actionState = UserActionState.NAV,
+              onClick = viewModel.navigation.onNavigateToUserSwitcher)
 
           if (isAdmin) {
-            item {
-              Spacer(modifier = Modifier.height(4.dp))
-              AdminTextView { handler.openUri(Links.ADMIN_URL) }
-            }
+            Spacer(modifier = Modifier.height(4.dp))
+            AdminTextView { handler.openUri(Links.ADMIN_URL) }
           }
 
-          settingsBundles.forEach { bundle ->
-            item { Lists.SectionDivider() }
+          SettingRow(viewModel.dns)
 
-            itemsWithDividers(bundle.settings) { setting -> SettingRow(setting) }
+          Lists.ItemDivider()
+          SettingRow(viewModel.tailnetLock)
+
+          Lists.ItemDivider()
+          SettingRow(viewModel.permissions)
+
+          Lists.ItemDivider()
+          SettingRow(viewModel.about)
+
+          Lists.ItemDivider()
+          SettingRow(viewModel.bugReport)
+
+          if (BuildConfig.DEBUG) {
+            Lists.ItemDivider()
+            SettingRow(viewModel.mdmDebug)
+          }
+
+          managedBy?.let {
+            Lists.ItemDivider()
+            SettingRow(it)
           }
         }
       }
@@ -76,48 +89,57 @@ fun SettingsView(
 
 @Composable
 fun SettingRow(setting: Setting) {
-  val enabled = setting.enabled.collectAsState().value
-  val swVal = setting.isOn?.collectAsState()?.value ?: false
-  val txtVal = setting.value?.collectAsState()?.value
-
   Box {
     when (setting.type) {
-      SettingType.TEXT ->
-          ListItem(
-              modifier = Modifier.clickable { if (enabled) setting.onClick() },
-              headlineContent = {
-                Text(
-                    setting.title.getString(),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color =
-                        if (setting.destructive) ts_color_dark_desctrutive_text
-                        else MaterialTheme.colorScheme.primary)
-              },
-          )
-      SettingType.SWITCH ->
-          ListItem(
-              modifier = Modifier.clickable { if (enabled) setting.onClick() },
-              headlineContent = { Text(setting.title.getString()) },
-              trailingContent = {
-                TintedSwitch(checked = swVal, onCheckedChange = setting.onToggle, enabled = enabled)
-              })
+      SettingType.TEXT -> TextRow(setting)
+      SettingType.SWITCH -> SwitchRow(setting)
       SettingType.NAV -> {
-        ListItem(
-            modifier = Modifier.clickable { if (enabled) setting.onClick() },
-            headlineContent = {
-              Text(
-                  setting.title.getString(),
-                  style = MaterialTheme.typography.bodyMedium,
-                  color =
-                      if (setting.destructive) ts_color_dark_desctrutive_text
-                      else MaterialTheme.colorScheme.primary)
-            },
-            supportingContent = {
-              txtVal?.let { Text(text = it, style = MaterialTheme.typography.bodyMedium) }
-            })
+        NavRow(setting)
       }
     }
   }
+}
+
+@Composable
+private fun TextRow(setting: Setting) {
+  val enabled = setting.enabled.collectAsState().value
+  ListItem(
+      modifier = Modifier.clickable { if (enabled) setting.onClick() },
+      headlineContent = {
+        Text(
+            setting.title ?: stringResource(setting.titleRes),
+            style = MaterialTheme.typography.bodyMedium,
+            color =
+                if (setting.destructive) ts_color_dark_desctrutive_text
+                else MaterialTheme.colorScheme.primary)
+      },
+  )
+}
+
+@Composable
+private fun SwitchRow(setting: Setting) {
+  val enabled = setting.enabled.collectAsState().value
+  val swVal = setting.isOn?.collectAsState()?.value ?: false
+  ListItem(
+      modifier = Modifier.clickable { if (enabled) setting.onClick() },
+      headlineContent = { Text(setting.title ?: stringResource(setting.titleRes)) },
+      trailingContent = {
+        TintedSwitch(checked = swVal, onCheckedChange = setting.onToggle, enabled = enabled)
+      })
+}
+
+@Composable
+private fun NavRow(setting: Setting) {
+  ListItem(
+      modifier = Modifier.clickable { setting.onClick() },
+      headlineContent = {
+        Text(
+            setting.title ?: stringResource(setting.titleRes),
+            style = MaterialTheme.typography.bodyMedium,
+            color =
+                if (setting.destructive) ts_color_dark_desctrutive_text
+                else MaterialTheme.colorScheme.primary)
+      })
 }
 
 @Composable

--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/DNSSettingsViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/DNSSettingsViewModel.kt
@@ -39,7 +39,7 @@ class DNSSettingsViewModel() : IpnViewModel() {
   val useDNSSetting =
       Setting(
           R.string.use_ts_dns,
-          SettingType.SWITCH,
+          type = SettingType.SWITCH,
           isOn = MutableStateFlow(Notifier.prefs.value?.CorpDNS),
           onToggle = {
             LoadingIndicator.start()

--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/ExitNodePickerViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/ExitNodePickerViewModel.kt
@@ -60,7 +60,7 @@ class ExitNodePickerViewModel(private val nav: ExitNodePickerNav) : IpnViewModel
   val allowLANAccessSetting =
       Setting(
           R.string.allow_lan_access,
-          SettingType.SWITCH,
+          type = SettingType.SWITCH,
           isOn = MutableStateFlow(Notifier.prefs.value?.ExitNodeAllowLANAccess),
           enabled = MutableStateFlow(true),
           onToggle = {

--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/IpnViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/IpnViewModel.kt
@@ -12,7 +12,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.tailscale.ipn.App
 import com.tailscale.ipn.IPNReceiver
-import com.tailscale.ipn.mdm.MDMSettings
 import com.tailscale.ipn.ui.localapi.Client
 import com.tailscale.ipn.ui.model.Ipn
 import com.tailscale.ipn.ui.model.IpnLocal
@@ -28,10 +27,6 @@ import kotlinx.coroutines.launch
  * notifications, managing login/logout, updating preferences, etc.
  */
 open class IpnViewModel : ViewModel() {
-  companion object {
-    val mdmSettings: StateFlow<MDMSettings> = MutableStateFlow(MDMSettings())
-  }
-
   protected val TAG = this::class.simpleName
 
   val loggedInUser: StateFlow<IpnLocal.LoginProfile?> = MutableStateFlow(null)

--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/UserSwitcherViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/UserSwitcherViewModel.kt
@@ -15,14 +15,11 @@ class UserSwitcherViewModel : IpnViewModel() {
   val showDialog: StateFlow<ErrorDialogType?> = MutableStateFlow(null)
 
   val loginSetting =
-      Setting(
-          title = ComposableStringFormatter(R.string.reauthenticate),
-          type = SettingType.NAV,
-          onClick = { login {} })
+      Setting(titleRes = R.string.reauthenticate, type = SettingType.NAV, onClick = { login {} })
 
   val logoutSetting =
       Setting(
-          title = ComposableStringFormatter(R.string.log_out),
+          titleRes = R.string.log_out,
           destructive = true,
           type = SettingType.TEXT,
           onClick = {
@@ -35,7 +32,7 @@ class UserSwitcherViewModel : IpnViewModel() {
 
   val addProfileSetting =
       Setting(
-          title = ComposableStringFormatter(R.string.add_account),
+          titleRes = R.string.add_account,
           type = SettingType.NAV,
           onClick = {
             addProfile {


### PR DESCRIPTION
Updates tailscale/corp#18202

@sonovawolf noticed that the Settings view was slow to load. In the logs, I was able to see these kinds of warnings when opening the settings view, a warning that so far I'm not seeing anywhere else.

```
Choreographer  I  Skipped 38 frames!  The application may be doing too much work on its main thread.
```

This PR does a couple of things to address this:

1. The most impactful is to refactor MDMSettings to use StateFlows and only call RestrictionsManager once to initialize those (and do so outside of the UI thread)
2. Simplifies the settings model and takes out some StateFlows and corresponding `collectWithState()` calls

The first part is implemented in reusable fashion as the extension method `ViewModel.launchForInit`