### PR TITLE
android/ui: hide mullvad exit nodes in peer list

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/ui/model/TailCfg.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/model/TailCfg.kt
@@ -79,6 +79,9 @@ class Tailcfg {
     // isExitNode reproduces the Go logic in local.go peerStatusFromNode
     val isExitNode: Boolean =
         AllowedIPs?.contains("0.0.0.0/0") ?: false && AllowedIPs?.contains("::/0") ?: false
+
+    val isMullvadNode: Boolean
+      get() = Name.endsWith(".mullvad.ts.net.")
   }
 
   @Serializable

--- a/android/src/main/java/com/tailscale/ipn/ui/util/PeerHelper.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/util/PeerHelper.kt
@@ -45,10 +45,13 @@ class PeerCategorizer(scope: CoroutineScope) {
       // (jonathan) TODO: MDM -> currentUser, otherUsers, taggedDevices
       val userId = peer.User
 
-      if (!grouped.containsKey(userId)) {
-        grouped[userId] = mutableListOf()
+      // Mullvad based nodes should not be shown in the peer list
+      if (!peer.isMullvadNode) {
+        if (!grouped.containsKey(userId)) {
+          grouped[userId] = mutableListOf()
+        }
+        grouped[userId]?.add(peer)
       }
-      grouped[userId]?.add(peer)
     }
 
     val me = netmap.currentUserProfile()


### PR DESCRIPTION
Updates tailscale/corp#18202

hides the mullvad nodes (basesd on their Name) in the peers list.  This differs slightly from the iOS logic where we use the Location property, but it feels like a better approach since Location is optional in the HostInfo and may not always be present.