### PR TITLE
build.gradle: add shared keystore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # Ignore Gradle build output directory
 build
 
+# Ignore Gradle configuration file
+shared-debug.keystore
+
 # The destination for the Go Android archive.
 android/libs
 android_legacy/libs

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,6 +30,9 @@ apply plugin: 'com.android.application'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 apply plugin: 'com.ncorti.ktfmt.gradle'
 
+def keystoreProperties = new Properties()
+file("local.properties").withInputStream { keystoreProperties.load(it) }
+
 android {
     ndkVersion "23.1.7779620"
     compileSdkVersion 34
@@ -60,6 +63,21 @@ android {
         }
     }
     namespace 'com.tailscale.ipn'
+
+    signingConfigs {
+        debug {
+            if (keystoreProperties.containsKey('debugKeystoreFile') &&
+                keystoreProperties.containsKey('debugKeystorePassword') &&
+                keystoreProperties.containsKey('debugKeyAlias') &&
+                keystoreProperties.containsKey('debugKeyPassword')) {
+                // Use the debug signing config if all required properties are present
+                keyAlias keystoreProperties['debugKeyAlias']
+                keyPassword keystoreProperties['debugKeyPassword']
+                storeFile file(keystoreProperties['debugKeystoreFile'])
+                storePassword keystoreProperties['debugKeystorePassword']
+            }
+        }
+    }
 }
 
 dependencies {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,3 +3,4 @@ android.nonFinalResIds=false
 android.nonTransitiveRClass=false
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m
+

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -80,6 +80,14 @@
                 <data android:mimeType="text/*" />
                 <data android:mimeType="video/*" />
             </intent-filter>
+            <intent-filter android:autoVerify="true" >
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:host="www.tailscale.com"
+                    android:scheme="https" />
+            </intent-filter>
         </activity>
 
 


### PR DESCRIPTION
Configure gradle to use shared keystore so that we can enable App Links for non play store signed builds

Updates tailscale/corp#18202