### PR TITLE
android/ui: disable landscape on small screen devices

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/MainActivity.kt
+++ b/android/src/main/java/com/tailscale/ipn/MainActivity.kt
@@ -7,6 +7,9 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.RestrictionsManager
+import android.content.pm.ActivityInfo
+import android.content.res.Configuration.SCREENLAYOUT_SIZE_LARGE
+import android.content.res.Configuration.SCREENLAYOUT_SIZE_MASK
 import android.net.Uri
 import android.net.VpnService
 import android.os.Bundle
@@ -71,8 +74,19 @@ class MainActivity : ComponentActivity() {
     private const val TAG = "Main Activity"
   }
 
+  private fun Context.isLandscapeCapable(): Boolean {
+    return (resources.configuration.screenLayout and SCREENLAYOUT_SIZE_MASK) >=
+        SCREENLAYOUT_SIZE_LARGE
+  }
+
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+
+    // (jonathan) TODO: Force the app to be portrait on small screens until we have
+    // proper landscape layout support
+    if (!isLandscapeCapable()) {
+      requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+    }
 
     setContent {
       AppTheme {


### PR DESCRIPTION
Updates tailscale/corp#18202

For our initial release, we will only support landscape on large screen devices (tablets, chromebooks).

Tested on a tabletizable chromebook and a variety of simulators and this seems to be a decent compromise until we have fully landscape capable layouts.