### PR TITLE
android/ui: show the switching-to user immediately on FUS switch

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/IpnViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/IpnViewModel.kt
@@ -38,11 +38,8 @@ open class IpnViewModel : ViewModel() {
   init {
     viewModelScope.launch {
       Notifier.state.collect {
-        // Refresh the user profiles if we're transitioning out of the
-        // NeedsLogin state.
-        if (it == Ipn.State.NeedsLogin) {
-          viewModelScope.launch { loadUserProfiles() }
-        }
+        // Reload the user profiles on all state transitions to ensure loggedInUser is correct
+        viewModelScope.launch { loadUserProfiles() }
       }
     }
 


### PR DESCRIPTION
Updates tailscale/corp#18202

This moves the logged-in-user to global state (which is is) and sets it immediately when you switch tailnets.  On failure, we will set things back to the prior user.

This fixes the issue of seeing the "old" user while the transition is happening.