### PR TITLE
android/ui: change exit node disable string to 'stop'

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/ui/view/MainView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/MainView.kt
@@ -213,7 +213,7 @@ fun ExitNodeStatus(navAction: () -> Unit, viewModel: MainViewModel) {
                   Button(
                       colors = MaterialTheme.colorScheme.secondaryButton,
                       onClick = { viewModel.disableExitNode() }) {
-                        Text(stringResource(R.string.disable))
+                        Text(stringResource(R.string.stop))
                       }
                 }
               })

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -124,7 +124,7 @@
     <string name="run_exit_node_explainer_running">Other devices in your tailnet can now route their internet traffic through this Android device. Make sure to approve this exit node in the admin console in order for other devices to see it.</string>
     <string name="enabled">Enabled</string>
     <string name="disabled">Disabled</string>
-    <string name="disable">Disable</string>
+    <string name="stop">Stop</string>
 
     <!-- Strings for the tailnet lock screen -->
     <string name="tailnet_lock">Tailnet lock</string>


### PR DESCRIPTION
Updates tailscale/corp#18202

Updates the exit node stop button to 'stop' instead of 'disable' pending the required back end changes to remember the preferred exit node.