### PR TITLE
android/ui: add compose-style splash screen

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -91,6 +91,7 @@ dependencies {
     implementation 'androidx.activity:activity-compose:1.8.2'
     implementation "com.google.accompanist:accompanist-permissions:$accompanist_version"
     implementation "com.google.accompanist:accompanist-systemuicontroller:$accompanist_version"
+    implementation "androidx.core:core-splashscreen:1.1.0-alpha02"
 
     // Navigation dependencies.
     def nav_version = "2.7.7"

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -31,7 +31,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="Tailscale"
         android:roundIcon="@mipmap/ic_launcher_round"
-        android:theme="@style/Theme.AppCompat">
+        android:theme="@style/Theme.App.SplashScreen">
         <activity
             android:name="MainActivity"
             android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|keyboardHidden"

--- a/android/src/main/java/com/tailscale/ipn/MainActivity.kt
+++ b/android/src/main/java/com/tailscale/ipn/MainActivity.kt
@@ -24,6 +24,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.core.net.toUri
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -87,6 +88,8 @@ class MainActivity : ComponentActivity() {
     if (!isLandscapeCapable()) {
       requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
     }
+
+    installSplashScreen()
 
     setContent {
       AppTheme {

--- a/android/src/main/res/values/splash.xml
+++ b/android/src/main/res/values/splash.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+<style name="Theme.App.SplashScreen" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenBackground">@color/ic_launcher_background</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>
+        <item name="postSplashScreenTheme">@style/Theme.AppCompat</item>
+</style>
+</resources>


### PR DESCRIPTION
Updates tailscale/corp#18202

Updates the splash screen to the modern themed jetpack compose variant.