### PR TITLE
android/ui: treat NoState similar to Starting

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/MainViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/MainViewModel.kt
@@ -43,7 +43,8 @@ class MainViewModel : IpnViewModel() {
     viewModelScope.launch {
       Notifier.state.collect { state ->
         stateRes.set(state.userStringRes())
-        vpnToggleState.set((state == State.Running || state == State.Starting))
+        vpnToggleState.set(
+            (state == State.Running || state == State.Starting || state == State.NoState))
       }
     }
 


### PR DESCRIPTION
Updates tailscale/corp#18202

NoState is now treated similar to starting for the on/off switch (which matches behaviour of the string)

This makes the switch transition to "on" immediately.  "null" is where we start.