### PR TITLE
build.gradle, Makefile: remove custom fdroid build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,10 +171,6 @@ $(LIBTAILSCALE): Makefile android/libs $(LIBTAILSCALE_SOURCES) $(GOBIN)/gomobile
 
 libtailscale: $(LIBTAILSCALE)
 
-tailscale-new-fdroid.apk: $(LIBTAILSCALE)
-	(cd android && ./gradlew test assembleFdroidDebug)
-	mv android/build/outputs/apk/fdroid/debug/android-fdroid-debug.apk $@
-
 tailscale-new-debug.apk: $(LIBTAILSCALE)
 	(cd android && ./gradlew test assemblePlayDebug)
 	mv android/build/outputs/apk/play/debug/android-play-debug.apk $@

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,15 +51,6 @@ android {
         kotlinCompilerExtensionVersion = "$kotlin_compose_version"
     }
     flavorDimensions "version"
-    productFlavors {
-        fdroid {
-            // The fdroid flavor contains only free dependencies and is suitable
-            // for the F-Droid app store.
-        }
-        play {
-            // The play flavor contains all features and is for the Play Store.
-        }
-    }
     namespace 'com.tailscale.ipn'
 }
 


### PR DESCRIPTION
We're no longer using GoogleSignIn, so there's no need for separate product flavors Updates tailscale/corp#18202