### PR TITLE
android/ui: handle NeedsMachineAuth state

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/MainActivity.kt
+++ b/android/src/main/java/com/tailscale/ipn/MainActivity.kt
@@ -162,7 +162,7 @@ class MainActivity : ComponentActivity() {
                           onNavigateToRunAsExitNode = { navController.navigate("runExitNode") })
 
                   composable("main", enterTransition = { fadeIn(animationSpec = tween(150)) }) {
-                    MainView(navigation = mainViewNav)
+                    MainView(loginAtUrl = ::login, navigation = mainViewNav)
                   }
                   composable("settings") { SettingsView(settingsNav) }
                   composable("exitNodes") { ExitNodePicker(exitNodePickerNav) }

--- a/android/src/main/java/com/tailscale/ipn/ui/model/TailCfg.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/model/TailCfg.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import com.tailscale.ipn.R
+import com.tailscale.ipn.ui.Links
 import com.tailscale.ipn.ui.theme.off
 import com.tailscale.ipn.ui.theme.on
 import com.tailscale.ipn.ui.util.ComposableStringFormatter
@@ -90,6 +91,16 @@ class Tailcfg {
       get() =
           Capabilities?.contains("https://tailscale.com/cap/is-admin") == true ||
               CapMap?.contains("https://tailscale.com/cap/is-admin") == true
+
+    // Derives the url to directly administer a node
+    val nodeAdminUrl: String
+      get() = primaryIPv4Address?.let { "${Links.ADMIN_URL}/machines/${it}" } ?: Links.ADMIN_URL
+
+    val primaryIPv4Address: String?
+      get() = displayAddresses.firstOrNull { it.type == DisplayAddress.addrType.V4 }?.address
+
+    val primaryIPv6Address: String?
+      get() = displayAddresses.firstOrNull { it.type == DisplayAddress.addrType.V6 }?.address
 
     // isExitNode reproduces the Go logic in local.go peerStatusFromNode
     val isExitNode: Boolean =

--- a/android/src/main/java/com/tailscale/ipn/ui/util/DisplayAddress.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/util/DisplayAddress.kt
@@ -3,7 +3,7 @@
 
 package com.tailscale.ipn.ui.util
 
-class DisplayAddress(val ip: String) {
+class DisplayAddress(ip: String) {
   enum class addrType {
     V4,
     V6,

--- a/android/src/main/java/com/tailscale/ipn/ui/view/PeerView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/PeerView.kt
@@ -28,7 +28,7 @@ fun PeerView(
     peer: Tailcfg.Node,
     selfPeer: String? = null,
     stateVal: Ipn.State? = null,
-    subtitle: () -> String = { peer.Addresses?.first()?.split("/")?.first() ?: "" },
+    subtitle: () -> String = { peer.primaryIPv4Address ?: peer.primaryIPv6Address ?: "" },
     onClick: (Tailcfg.Node) -> Unit = {},
     trailingContent: @Composable () -> Unit = {}
 ) {

--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/MainViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/MainViewModel.kt
@@ -79,7 +79,7 @@ private fun State?.userStringRes(): Int {
     State.NoState -> R.string.waiting
     State.InUseOtherUser -> R.string.placeholder
     State.NeedsLogin -> R.string.please_login
-    State.NeedsMachineAuth -> R.string.placeholder
+    State.NeedsMachineAuth -> R.string.needs_machine_auth
     State.Stopped -> R.string.stopped
     State.Starting -> R.string.starting
     State.Running -> R.string.connected

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -60,7 +60,10 @@
     <string name="deviceKeyNeverExpires">Device key does not expire</string>
     <string name="deviceKeyExpires">Device key expires %s</string>
     <string name="deviceKeyExpired">Device key expired %s</string>
-
+    <string name="machine_auth_required">Admin approval required</string>
+    <string name="machine_auth_explainer">This device must be approved by an administrator before it can connect to the tailnet.</string>
+    <string name="open_admin_console">Open admin console</string>
+    <string name="needs_machine_auth">Authorization required</string>
 
     <!-- Strings for peer details -->
     <string name="os">OS</string>
@@ -226,6 +229,6 @@
     <string name="getStarted">Get Started</string>
     <string name="welcome1">Tailscale is a mesh VPN for securely connecting your devices.</string>
     <string name="welcome2">All connections are device-to-device, so we never see your data. We collect and use your email address and name, as well as your device name, OS version, and IP address in order to help you to connect your devices and manage your settings. We log when you are connected to your network.</string>
-        <string name="scan_to_connect_to_your_tailnet">Scan this QR code to log in to your tailnet</string>
+    <string name="scan_to_connect_to_your_tailnet">Scan this QR code to log in to your tailnet</string>
 
 </resources>


### PR DESCRIPTION
Fixes corp#19119

Adds a variation on the ConnectView to render a header and explainer text for the NeedsMachineAuth state.  A button to take you directly to the admin page is presented if you are an admin.

![Screenshot 2024-04-12 at 10 50 23 AM](https://github.com/tailscale/tailscale-android/assets/779591/c90dc8bb-5a9c-465f-a632-e0a5a57966d2)

