### PR TITLE
ui: don't show key expiry warning if key doesn't expire

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/ui/model/TailCfg.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/model/TailCfg.kt
@@ -112,6 +112,9 @@ class Tailcfg {
     val displayName: String
       get() = ComputedName ?: Name
 
+    val keyDoesNotExpire: Boolean
+      get() = KeyExpiry == "0001-01-01T00:00:00Z"
+
     fun isSelfNode(netmap: Netmap.NetworkMap): Boolean = StableID == netmap.SelfNode.StableID
 
     fun connectedOrSelfNode(nm: Netmap.NetworkMap?) =
@@ -142,7 +145,13 @@ class Tailcfg {
               PeerSettingInfo(R.string.os, ComposableStringFormatter(Hostinfo.OS!!)),
           )
         }
-        result.add(PeerSettingInfo(R.string.key_expiry, TimeUtil.keyExpiryFromGoTime(KeyExpiry)))
+        if (keyDoesNotExpire) {
+          result.add(
+              PeerSettingInfo(
+                  R.string.key_expiry, ComposableStringFormatter(R.string.deviceKeyNeverExpires)))
+        } else {
+          result.add(PeerSettingInfo(R.string.key_expiry, TimeUtil.keyExpiryFromGoTime(KeyExpiry)))
+        }
         return result
       }
 

--- a/android/src/main/java/com/tailscale/ipn/ui/view/MainView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/MainView.kt
@@ -469,7 +469,7 @@ fun PeerList(
 fun ExpiryNotificationIfNecessary(netmap: Netmap.NetworkMap?, action: () -> Unit = {}) {
   // Key expiry warning shown only if the key is expiring within 24 hours (or has already expired)
   val networkMap = netmap ?: return
-  if (!TimeUtil.isWithin24Hours(networkMap.SelfNode.KeyExpiry)) {
+  if (!TimeUtil.isWithin24Hours(networkMap.SelfNode.KeyExpiry) || networkMap.SelfNode.keyDoesNotExpire) {
     return
   }
 


### PR DESCRIPTION
Fixes tailscale/tailscale#11701

We should not show a key expiry warning if the KeyExpiry is a zero-value time.Time