### PR TITLE
android: pass interface name to go

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/App.kt
+++ b/android/src/main/java/com/tailscale/ipn/App.kt
@@ -168,14 +168,14 @@ class App : Application(), libtailscale.AppContext {
             }
 
             if (dns.updateDNSFromNetwork(sb.toString())) {
-              Libtailscale.onDnsConfigChanged()
+              Libtailscale.onDNSConfigChanged(linkProperties?.getInterfaceName())
             }
           }
 
           override fun onLost(network: Network) {
             super.onLost(network)
             if (dns.updateDNSFromNetwork("")) {
-              Libtailscale.onDnsConfigChanged()
+              Libtailscale.onDNSConfigChanged("")
             }
           }
         })

--- a/libtailscale/backend.go
+++ b/libtailscale/backend.go
@@ -222,9 +222,9 @@ func (a *App) runBackend(ctx context.Context) error {
 				netns.SetAndroidProtectFunc(nil)
 				service = nil
 			}
-		case <-onDNSConfigChanged:
+		case i := <-onDNSConfigChanged:
 			if b != nil {
-				go b.NetworkChanged()
+				go b.NetworkChanged(i)
 			}
 		}
 	}

--- a/libtailscale/callbacks.go
+++ b/libtailscale/callbacks.go
@@ -23,13 +23,14 @@ var (
 	// onGoogleToken receives google ID tokens.
 	onGoogleToken = make(chan string)
 
-	// onDNSConfigChanged is notified when the network changes and the DNS config needs to be updated.
-	onDNSConfigChanged = make(chan struct{}, 1)
+	// onDNSConfigChanged is notified when the network changes and the DNS config needs to be updated. It receives the updated interface name.
+	onDNSConfigChanged = make(chan string, 1)
 )
 
-func OnDnsConfigChanged() {
+// ifname is the interface name retrieved from LinkProperties on network change. An empty string is used if there is no network available.
+func OnDNSConfigChanged(ifname string) {
 	select {
-	case onDNSConfigChanged <- struct{}{}:
+	case onDNSConfigChanged <- ifname:
 	default:
 	}
 }

--- a/libtailscale/net.go
+++ b/libtailscale/net.go
@@ -227,7 +227,8 @@ func (b *backend) CloseTUNs() {
 	b.devices.Shutdown()
 }
 
-func (b *backend) NetworkChanged() {
+// ifname is the interface name retrieved from LinkProperties on network change. If a network is lost, an empty string is passed in.
+func (b *backend) NetworkChanged(ifname string) {
 	defer func() {
 		if p := recover(); p != nil {
 			log.Printf("panic in NetworkChanged %s: %s", p, debug.Stack())
@@ -235,6 +236,8 @@ func (b *backend) NetworkChanged() {
 		}
 	}()
 
+	// Set the interface name and alert the monitor.
+	interfaces.UpdateLastKnownDefaultRouteInterface(ifname)
 	if b.sys != nil {
 		if nm, ok := b.sys.NetMon.GetOK(); ok {
 			nm.InjectEvent()


### PR DESCRIPTION
Use Android API to pass interface name to Tailscale on network updates
Pull in OSS changes to include https://github.com/tailscale/tailscale/pull/11784 

Fixes tailscale/corp#19215