### PR TITLE
.github/licenses: remove gioui from license list

### DIFF
--- a/.github/licenses.tmpl
+++ b/.github/licenses.tmpl
@@ -18,4 +18,3 @@ Client][].  See also the dependencies in the [Tailscale CLI][].
  - [{{.Name}}](https://pkg.go.dev/{{.Name}}) ([{{.LicenseName}}]({{.LicenseURL}}))
 {{- end }}
  - [tailscale.com](https://pkg.go.dev/tailscale.com) ([BSD-3-Clause](https://github.com/tailscale/tailscale/blob/HEAD/LICENSE))
- - [Gio UI](https://gioui.org/) ([MIT License](https://git.sr.ht/~eliasnaur/gio/tree/main/item/LICENSE))


### PR DESCRIPTION
The android app no longer uses gioui.

Updates #cleanup