### PR TITLE
android/ui: fix exit node selection navigation

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/ExitNodePickerViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/ExitNodePickerViewModel.kt
@@ -139,7 +139,7 @@ class ExitNodePickerViewModel(private val nav: ExitNodePickerNav) : IpnViewModel
     prefsOut.ExitNodeID = node.id
 
     Client(viewModelScope).editPrefs(prefsOut) {
-      nav.onNavigateBackToExitNodes()
+      nav.onNavigateBackHome()
       LoadingIndicator.stop()
     }
   }


### PR DESCRIPTION
fixes tailscale/corp#19297

Selecting an exit node will now navigate the user back home (again).