### PR TITLE
mdm: add string array support in Android syspolicy_handler

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/App.kt
+++ b/android/src/main/java/com/tailscale/ipn/App.kt
@@ -45,6 +45,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import libtailscale.Libtailscale
 import java.io.File
 import java.io.IOException
@@ -446,5 +448,17 @@ class App : Application(), libtailscale.AppContext {
           Log.d("MDM", "$key is not defined on Android. Throwing NoSuchKeyException.")
           throw MDMSettings.NoSuchKeyException()
         }
+  }
+
+  @Throws(
+      IOException::class, GeneralSecurityException::class, MDMSettings.NoSuchKeyException::class)
+  override fun getSyspolicyStringArrayJSONValue(key: String): String {
+    val list = MDMSettings.allSettingsByKey[key]?.flow?.value as? List<String>
+    try {
+      return Json.encodeToString(list)
+    } catch (e: Exception) {
+      Log.d("MDM", "$key is not defined on Android. Throwing NoSuchKeyException.")
+      throw MDMSettings.NoSuchKeyException()
+    }
   }
 }

--- a/android/src/main/java/com/tailscale/ipn/mdm/MDMSettings.kt
+++ b/android/src/main/java/com/tailscale/ipn/mdm/MDMSettings.kt
@@ -51,7 +51,8 @@ object MDMSettings {
   val runExitNode = ShowHideMDMSetting("RunExitNode", "Run as Exit Node")
   val testMenu = ShowHideMDMSetting("TestMenu", "Show Debug Menu")
   val updateMenu = ShowHideMDMSetting("UpdateMenu", "“Update Available” menu item")
-
+  val allowedSuggestedExitNodes =
+      StringArrayListMDMSetting("AllowedSuggestedExitNodes", "Allowed Suggested Exit Nodes")
   val allSettings by lazy {
     MDMSettings::class
         .declaredMemberProperties

--- a/libtailscale/interfaces.go
+++ b/libtailscale/interfaces.go
@@ -51,6 +51,10 @@ type AppContext interface {
 
 	// GetSyspolicyBooleanValue returns whether the given system policy is enabled.
 	GetSyspolicyBooleanValue(key string) (bool, error)
+
+	// GetSyspolicyStringArrayValue returns the current string array value for the given system policy,
+	// expressed as a JSON string.
+	GetSyspolicyStringArrayJSONValue(key string) (string, error)
 }
 
 // IPNService corresponds to our IPNService in Java.

--- a/libtailscale/syspolicy_handler.go
+++ b/libtailscale/syspolicy_handler.go
@@ -4,6 +4,7 @@
 package libtailscale
 
 import (
+	"encoding/json"
 	"errors"
 	"log"
 
@@ -45,4 +46,24 @@ func (h syspolicyHandler) ReadUInt64(key string) (uint64, error) {
 	// TODO(angott): drop ReadUInt64 everywhere. We are not using it.
 	log.Fatalf("ReadUInt64 is not implemented on Android")
 	return 0, nil
+}
+
+func (h syspolicyHandler) ReadStringArray(key string) ([]string, error) {
+	if key == "" {
+		return nil, syspolicy.ErrNoSuchKey
+	}
+	retVal, err := h.a.appCtx.GetSyspolicyStringArrayJSONValue(key)
+	if err != nil && !errors.Is(err, syspolicy.ErrNoSuchKey) {
+		log.Printf("syspolicy: failed to get string array value via gomobile: %v", err)
+		return nil, err
+	}
+	if retVal == "" {
+		return nil, syspolicy.ErrNoSuchKey
+	}
+	var arr []string
+	jsonErr := json.Unmarshal([]byte(retVal), &arr)
+	if jsonErr != nil {
+		return nil, jsonErr
+	}
+	return arr, err
 }


### PR DESCRIPTION
Updates tailscale/corp#19459

Allows the Go backend to read string array values stored in the Android RestrictionsManager.