### PR TITLE
QuickToggleService: use undeprecated startActivityAndCollapse

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/QuickToggleService.java
+++ b/android/src/main/java/com/tailscale/ipn/QuickToggleService.java
@@ -3,8 +3,10 @@
 
 package com.tailscale.ipn;
 
+import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.service.quicksettings.Tile;
 import android.service.quicksettings.TileService;
 
@@ -18,6 +20,8 @@ public class QuickToggleService extends TileService {
     private static boolean ready;
     // currentTile tracks getQsTile while service is listening.
     private static Tile currentTile;
+    // Request code for opening activity.
+    private static int reqCode = 0;
 
     private static void updateTile() {
         Tile t;
@@ -73,7 +77,11 @@ public class QuickToggleService extends TileService {
         } else {
             // Start main activity.
             Intent i = getPackageManager().getLaunchIntentForPackage(getPackageName());
-            startActivityAndCollapse(i);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                startActivityAndCollapse(PendingIntent.getActivity(this, reqCode, i, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE));
+            } else {
+                startActivityAndCollapse(i);
+            }
         }
     }
 


### PR DESCRIPTION
startActivityAndCollapse(Intent) is deprecated for >= API 34, use startActivityAndCollapse(PendingIntent) instead

Fixes tailscale/corp#19546