### PR TITLE
ipn: provide subtitle in QuickToggleService

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/App.kt
+++ b/android/src/main/java/com/tailscale/ipn/App.kt
@@ -220,11 +220,8 @@ class App : Application(), libtailscale.AppContext {
   }
 
   fun setTileReady(ready: Boolean) {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
-      return
-    }
     QuickToggleService.setReady(this, ready)
-    Log.d("App", "Set Tile Ready: $ready $autoConnect")
+    Log.d("App", "Set Tile Ready: ready=$ready, autoConnect=$autoConnect")
     vpnReady = ready
     if (ready && autoConnect) {
       startVPN()
@@ -232,9 +229,6 @@ class App : Application(), libtailscale.AppContext {
   }
 
   fun setTileStatus(status: Boolean) {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
-      return
-    }
     QuickToggleService.setStatus(this, status)
   }
 
@@ -363,9 +357,6 @@ class App : Application(), libtailscale.AppContext {
   }
 
   fun createNotificationChannel(id: String?, name: String?, importance: Int) {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-      return
-    }
     val channel = NotificationChannel(id, name, importance)
     val nm: NotificationManagerCompat = NotificationManagerCompat.from(this)
     nm.createNotificationChannel(channel)

--- a/android/src/main/java/com/tailscale/ipn/QuickToggleService.java
+++ b/android/src/main/java/com/tailscale/ipn/QuickToggleService.java
@@ -23,7 +23,7 @@ public class QuickToggleService extends TileService {
     // Request code for opening activity.
     private static int reqCode = 0;
 
-    private static void updateTile() {
+    private static void updateTile(Context ctx) {
         Tile t;
         boolean act;
         synchronized (lock) {
@@ -33,6 +33,10 @@ public class QuickToggleService extends TileService {
         if (t == null) {
             return;
         }
+        t.setLabel("Tailscale");
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            t.setSubtitle(act ? ctx.getString(R.string.connected) : ctx.getString(R.string.not_connected));
+        }
         t.setState(act ? Tile.STATE_ACTIVE : Tile.STATE_INACTIVE);
         t.updateTile();
     }
@@ -41,14 +45,14 @@ public class QuickToggleService extends TileService {
         synchronized (lock) {
             ready = rdy;
         }
-        updateTile();
+        updateTile(ctx);
     }
 
     static void setStatus(Context ctx, boolean act) {
         synchronized (lock) {
             active = act;
         }
-        updateTile();
+        updateTile(ctx);
     }
 
     @Override
@@ -56,7 +60,7 @@ public class QuickToggleService extends TileService {
         synchronized (lock) {
             currentTile = getQsTile();
         }
-        updateTile();
+        updateTile(this.getApplicationContext());
     }
 
     @Override


### PR DESCRIPTION
Fixes ENG-3443

<img align="right" src="https://github.com/tailscale/tailscale-android/assets/9057073/6b8ea0b7-d97b-4b6b-93b8-079707cab19b" width="300" />

As discussed during design review, provides a "Connected" / "Not connected" subtitle in the Tailscale quick tile.

Also drops unnecessary SDK version checks in App.kt.


