### PR TITLE
android: fix Quick Settings tailscale

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/IPNService.kt
+++ b/android/src/main/java/com/tailscale/ipn/IPNService.kt
@@ -21,11 +21,6 @@ open class IPNService : VpnService(), libtailscale.IPNService {
   }
 
   override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-    if (intent != null && ACTION_STOP_VPN == intent.action) {
-      (applicationContext as App).autoConnect = false
-      close()
-      return START_NOT_STICKY
-    }
     val app = applicationContext as App
     if (intent != null && "android.net.VpnService" == intent.action) {
       // Start VPN and connect to it due to Always-on VPN
@@ -33,14 +28,9 @@ open class IPNService : VpnService(), libtailscale.IPNService {
       i.setPackage(packageName)
       i.setClass(applicationContext, IPNReceiver::class.java)
       sendBroadcast(i)
-      Libtailscale.requestVPN(this)
-      app.setWantRunning(true)
-      return START_STICKY
     }
     Libtailscale.requestVPN(this)
-    if (app.vpnReady && app.autoConnect) {
-      app.setWantRunning(true)
-    }
+    app.setWantRunning(true)
     return START_STICKY
   }
 
@@ -134,6 +124,5 @@ open class IPNService : VpnService(), libtailscale.IPNService {
 
   companion object {
     const val ACTION_REQUEST_VPN = "com.tailscale.ipn.REQUEST_VPN"
-    const val ACTION_STOP_VPN = "com.tailscale.ipn.STOP_VPN"
   }
 }

--- a/android/src/main/java/com/tailscale/ipn/QuickToggleService.java
+++ b/android/src/main/java/com/tailscale/ipn/QuickToggleService.java
@@ -13,8 +13,6 @@ import android.service.quicksettings.TileService;
 public class QuickToggleService extends TileService {
     // lock protects the static fields below it.
     private static final Object lock = new Object();
-    // Active tracks whether the VPN is active.
-    private static boolean active;
     // Ready tracks whether the tailscale backend is
     // ready to switch on/off.
     private static boolean ready;
@@ -28,7 +26,7 @@ public class QuickToggleService extends TileService {
         boolean act;
         synchronized (lock) {
             t = currentTile;
-            act = active && ready;
+            act = ready;
         }
         if (t == null) {
             return;
@@ -44,13 +42,6 @@ public class QuickToggleService extends TileService {
     static void setReady(Context ctx, boolean rdy) {
         synchronized (lock) {
             ready = rdy;
-        }
-        updateTile(ctx);
-    }
-
-    static void setStatus(Context ctx, boolean act) {
-        synchronized (lock) {
-            active = act;
         }
         updateTile(ctx);
     }
@@ -92,7 +83,7 @@ public class QuickToggleService extends TileService {
     private void onTileClick() {
         boolean act;
         synchronized (lock) {
-            act = active && ready;
+            act = ready;
         }
         Intent i = new Intent(act ? IPNReceiver.INTENT_DISCONNECT_VPN : IPNReceiver.INTENT_CONNECT_VPN);
         i.setPackage(getPackageName());

--- a/android/src/main/java/com/tailscale/ipn/StartVPNWorker.java
+++ b/android/src/main/java/com/tailscale/ipn/StartVPNWorker.java
@@ -25,11 +25,7 @@ public final class StartVPNWorker extends Worker {
     @Override
     public Result doWork() {
         App app = ((App) getApplicationContext());
-
-        // We will start the VPN from the background
-        app.setAutoConnect(true);
         // We need to make sure we prepare the VPN Service, just in case it isn't prepared.
-
         Intent intent = VpnService.prepare(app);
         if (intent == null) {
             // If null then the VPN is already prepared and/or it's just been prepared because we have permission

--- a/android/src/main/java/com/tailscale/ipn/ui/notifier/Notifier.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/notifier/Notifier.kt
@@ -31,7 +31,7 @@ object Notifier {
   private val decoder = Json { ignoreUnknownKeys = true }
 
   // Global App State
-  val tileReady: StateFlow<Boolean> = MutableStateFlow(false)
+  val tileActive: StateFlow<Boolean> = MutableStateFlow(false)
   val readyToPrepareVPN: StateFlow<Boolean> = MutableStateFlow(false)
 
   // General IPN Bus State
@@ -82,7 +82,7 @@ object Notifier {
           }
       state.collect { currstate ->
         readyToPrepareVPN.set(currstate > Ipn.State.Stopped)
-        tileReady.set(currstate >= Ipn.State.Stopped)
+        tileActive.set(currstate > Ipn.State.Stopped)
       }
     }
   }


### PR DESCRIPTION
-Get rid of unused stopVPN() function
-Get rid of unused ACTION_STOP_VPN intent handling; this is redundant with DISCONNECT_VPN intent -Tile active state should only depend on ipn state, and not the results of editing the prefs with wantRunning set. It should be active iff ipn.State > Stopped

Fixes tailscale/tailscale#11920