### PR TITLE
android/makefile: build and sign standalone apk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ android/local.properties
 # Output files from the Makefile:
 tailscale-debug.apk
 tailscale-release.aab
+tailscale-release.apk
 tailscale-fdroid.apk
 tailscale-new-fdroid.apk
 tailscale-new-debug.apk


### PR DESCRIPTION
Builds and signs a raw apk suitable for posting on packages.