### PR TITLE
android: add persistent notification with VPN status

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/IPNService.kt
+++ b/android/src/main/java/com/tailscale/ipn/IPNService.kt
@@ -97,32 +97,8 @@ open class IPNService : VpnService(), libtailscale.IPNService {
     return VPNServiceBuilder(b)
   }
 
-  fun notify(title: String?, message: String?) {
-    val builder: NotificationCompat.Builder =
-        NotificationCompat.Builder(this, App.NOTIFY_CHANNEL_ID)
-            .setSmallIcon(R.drawable.ic_notification)
-            .setContentTitle(title)
-            .setContentText(message)
-            .setContentIntent(configIntent())
-            .setAutoCancel(true)
-            .setOnlyAlertOnce(true)
-            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-    val nm: NotificationManagerCompat = NotificationManagerCompat.from(this)
-    nm.notify(App.NOTIFY_NOTIFICATION_ID, builder.build())
-  }
-
-  fun updateStatusNotification(title: String?, message: String?) {
-    val builder: NotificationCompat.Builder =
-        NotificationCompat.Builder(this, App.STATUS_CHANNEL_ID)
-            .setSmallIcon(R.drawable.ic_notification)
-            .setContentTitle(title)
-            .setContentText(message)
-            .setContentIntent(configIntent())
-            .setPriority(NotificationCompat.PRIORITY_LOW)
-    startForeground(App.STATUS_NOTIFICATION_ID, builder.build())
-  }
-
   companion object {
     const val ACTION_REQUEST_VPN = "com.tailscale.ipn.REQUEST_VPN"
+    const val ACTION_STOP_VPN = "com.tailscale.ipn.STOP_VPN"
   }
 }

--- a/android/src/main/java/com/tailscale/ipn/MainActivity.kt
+++ b/android/src/main/java/com/tailscale/ipn/MainActivity.kt
@@ -16,6 +16,7 @@ import android.net.VpnService
 import android.os.Bundle
 import android.provider.Settings
 import android.util.Log
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.ActivityResultLauncher
@@ -348,9 +349,9 @@ class MainActivity : ComponentActivity() {
 
   private fun openApplicationSettings() {
     val intent =
-        Intent(
-            Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
-            Uri.fromParts("package", packageName, null))
+    Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
+      putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
+  }
     intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
     startActivity(intent)
   }

--- a/android/src/main/java/com/tailscale/ipn/ui/notifier/Notifier.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/notifier/Notifier.kt
@@ -31,7 +31,7 @@ object Notifier {
   private val decoder = Json { ignoreUnknownKeys = true }
 
   // Global App State
-  val tileActive: StateFlow<Boolean> = MutableStateFlow(false)
+  val connStatus: StateFlow<Boolean> = MutableStateFlow(false)
   val readyToPrepareVPN: StateFlow<Boolean> = MutableStateFlow(false)
 
   // General IPN Bus State
@@ -82,7 +82,7 @@ object Notifier {
           }
       state.collect { currstate ->
         readyToPrepareVPN.set(currstate > Ipn.State.Stopped)
-        tileActive.set(currstate > Ipn.State.Stopped)
+        connStatus.set(currstate > Ipn.State.Stopped)
       }
     }
   }

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -212,7 +212,7 @@
     <string name="permission_write_external_storage">Storage</string>
     <string name="permission_write_external_storage_needed">We use storage in order to receive files with Taildrop.</string>
     <string name="permission_post_notifications">Notifications</string>
-    <string name="permission_post_notifications_needed">We use notifications to help you troubleshoot broken connections, or notify you before you need to reauthenticate to your network.</string>
+    <string name="permission_post_notifications_needed">We use notifications to help you troubleshoot broken connections, or notify you before you need to reauthenticate to your network. Persistent status notifications are off by default and can be enabled in system settings. </string>
 
 
     <!-- Strings for the share activity -->
@@ -226,6 +226,7 @@
     <string name="taildrop_share_failed">Taildrop failed. Some files were not shared. Please try again.</string>
     <string name="taildrop_sending">Sending</string>
     <string name="taildrop_share_failed_short">Failed</string>
+    <string name="file_notification">File received</string>
 
 
     <!-- Error Dialog Titles -->


### PR DESCRIPTION
-When connected, tapping on the notification disconnects 
-When disconnected, tapping on the notification connects 
-Navigate to system notifications instead of app info when tapping on 'Notifications' 
-Add text to notification permissions request explaining that the persistent notification is off by default
-Clean up unused notification channel and methods

-Follow up will be to update logo depending on connection status

Fixes tailscale/tailscale#10104
![share_5306084378167387858](https://github.com/tailscale/tailscale-android/assets/135075563/db709d4a-2a94-49c8-90df-435c7f9b587c)
![Screenshot (May 1, 2024 11_47_22 AM)](https://github.com/tailscale/tailscale-android/assets/135075563/8eae9ca5-7557-401d-bd4a-72bbcf1a844c)
