### PR TITLE
android/ui: add mdm hooks

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/mdm/MDMSettings.kt
+++ b/android/src/main/java/com/tailscale/ipn/mdm/MDMSettings.kt
@@ -18,41 +18,71 @@ object MDMSettings {
 
   val forceEnabled = BooleanMDMSetting("ForceEnabled", "Force Enabled Connection Toggle")
 
+  // Handled on the backed
   val exitNodeID = StringMDMSetting("ExitNodeID", "Forced Exit Node: Stable ID")
+
+  // (jonathan) TODO: Unused but required. There is some funky go string duration parsing required
+  // here.
   val keyExpirationNotice = StringMDMSetting("KeyExpirationNotice", "Key Expiration Notice Period")
+
   val loginURL = StringMDMSetting("LoginURL", "Custom control server URL")
+
   val managedByCaption = StringMDMSetting("ManagedByCaption", "Managed By - Caption")
+
   val managedByOrganizationName =
       StringMDMSetting("ManagedByOrganizationName", "Managed By - Organization Name")
+
   val managedByURL = StringMDMSetting("ManagedByURL", "Managed By - Support URL")
+
+  // Handled on the backend
   val tailnet = StringMDMSetting("Tailnet", "Recommended/Required Tailnet Name")
 
   val hiddenNetworkDevices =
       StringArrayListMDMSetting("HiddenNetworkDevices", "Hidden Network Device Categories")
 
+  // Unused on Android
   val allowIncomingConnections =
       AlwaysNeverUserDecidesMDMSetting("AllowIncomingConnections", "Allow Incoming Connections")
+
+  // Unused on Android
   val detectThirdPartyAppConflicts =
       AlwaysNeverUserDecidesMDMSetting(
           "DetectThirdPartyAppConflicts", "Detect potentially problematic third-party apps")
+
   val exitNodeAllowLANAccess =
       AlwaysNeverUserDecidesMDMSetting(
           "ExitNodeAllowLANAccess", "Allow LAN Access when using an exit node")
+
+  // Handled on the backend
   val postureChecking =
       AlwaysNeverUserDecidesMDMSetting("PostureChecking", "Enable Posture Checking")
+
   val useTailscaleDNSSettings =
       AlwaysNeverUserDecidesMDMSetting("UseTailscaleDNSSettings", "Use Tailscale DNS Settings")
+
+  // Unused on Android
   val useTailscaleSubnets =
       AlwaysNeverUserDecidesMDMSetting("UseTailscaleSubnets", "Use Tailscale Subnets")
 
   val exitNodesPicker = ShowHideMDMSetting("ExitNodesPicker", "Exit Nodes Picker")
+
   val manageTailnetLock = ShowHideMDMSetting("ManageTailnetLock", "“Manage Tailnet lock” menu item")
+
+  // Unused on Android
   val resetToDefaults = ShowHideMDMSetting("ResetToDefaults", "“Reset to Defaults” menu item")
+
   val runExitNode = ShowHideMDMSetting("RunExitNode", "Run as Exit Node")
+
+  // Unused on Android
   val testMenu = ShowHideMDMSetting("TestMenu", "Show Debug Menu")
+
+  // Unused on Android
   val updateMenu = ShowHideMDMSetting("UpdateMenu", "“Update Available” menu item")
+
+  // (jonathan) TODO: Use this when suggested exit nodes are implemented
   val allowedSuggestedExitNodes =
       StringArrayListMDMSetting("AllowedSuggestedExitNodes", "Allowed Suggested Exit Nodes")
+
   val allSettings by lazy {
     MDMSettings::class
         .declaredMemberProperties

--- a/android/src/main/java/com/tailscale/ipn/mdm/MDMSettingsDefinitions.kt
+++ b/android/src/main/java/com/tailscale/ipn/mdm/MDMSettingsDefinitions.kt
@@ -81,7 +81,12 @@ class ShowHideMDMSetting(key: String, localizedTitle: String) :
 enum class AlwaysNeverUserDecides(val value: String) {
   Always("always"),
   Never("never"),
-  UserDecides("user-decides")
+  UserDecides("user-decides");
+
+  val hiddenFromUser: Boolean
+    get() {
+      return this != UserDecides
+    }
 }
 
 enum class ShowHide(val value: String) {

--- a/android/src/main/java/com/tailscale/ipn/ui/view/DNSSettingsView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/DNSSettingsView.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.tailscale.ipn.R
+import com.tailscale.ipn.mdm.MDMSettings
 import com.tailscale.ipn.ui.model.DnsType
 import com.tailscale.ipn.ui.notifier.Notifier
 import com.tailscale.ipn.ui.util.ClipboardValueView
@@ -48,6 +49,7 @@ fun DNSSettingsView(
         entry.value?.let { resolvers -> ViewableRoute(name = entry.key, resolvers) } ?: run { null }
       } ?: emptyList()
   val useCorpDNS = Notifier.prefs.collectAsState().value?.CorpDNS == true
+  val dnsSettingsMDMDisposition = MDMSettings.useTailscaleDNSSettings.flow.collectAsState().value
 
   Scaffold(topBar = { Header(R.string.dns_settings, onBack = backToSettings) }) { innerPadding ->
     LoadingIndicator.Wrap {
@@ -66,14 +68,16 @@ fun DNSSettingsView(
               },
               supportingContent = { Text(stringResource(state.caption)) })
 
-          Lists.ItemDivider()
-          Setting.Switch(
-              R.string.use_ts_dns,
-              isOn = useCorpDNS,
-              onToggle = {
-                LoadingIndicator.start()
-                model.toggleCorpDNS { LoadingIndicator.stop() }
-              })
+          if (!dnsSettingsMDMDisposition.hiddenFromUser) {
+            Lists.ItemDivider()
+            Setting.Switch(
+                R.string.use_ts_dns,
+                isOn = useCorpDNS,
+                onToggle = {
+                  LoadingIndicator.start()
+                  model.toggleCorpDNS { LoadingIndicator.stop() }
+                })
+          }
         }
 
         if (resolvers.isNotEmpty()) {
@@ -107,5 +111,5 @@ fun DNSSettingsView(
 fun DNSSettingsViewPreview() {
   val vm = DNSSettingsViewModel()
   vm.enablementState.set(DNSEnablementState.ENABLED)
-  DNSSettingsView(backToSettings = { }, vm)
+  DNSSettingsView(backToSettings = {}, vm)
 }

--- a/android/src/main/java/com/tailscale/ipn/ui/view/ExitNodePicker.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/ExitNodePicker.kt
@@ -21,6 +21,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.tailscale.ipn.R
+import com.tailscale.ipn.mdm.MDMSettings
+import com.tailscale.ipn.mdm.ShowHide
 import com.tailscale.ipn.ui.notifier.Notifier
 import com.tailscale.ipn.ui.theme.disabledListItem
 import com.tailscale.ipn.ui.theme.listItem
@@ -45,6 +47,9 @@ fun ExitNodePicker(
       val mullvadExitNodeCount = model.mullvadExitNodeCount.collectAsState().value
       val anyActive = model.anyActive.collectAsState()
       val allowLANAccess = Notifier.prefs.collectAsState().value?.ExitNodeAllowLANAccess == true
+      val showRunAsExitNode = MDMSettings.runExitNode.flow.collectAsState().value
+      val allowLanAccessMDMDisposition =
+          MDMSettings.exitNodeAllowLANAccess.flow.collectAsState().value
 
       LazyColumn(modifier = Modifier.padding(innerPadding)) {
         item(key = "header") {
@@ -55,8 +60,11 @@ fun ExitNodePicker(
                   online = true,
                   selected = !anyActive.value,
               ))
-          Lists.ItemDivider()
-          RunAsExitNodeItem(nav = nav, viewModel = model)
+
+          if (showRunAsExitNode == ShowHide.Show) {
+            Lists.ItemDivider()
+            RunAsExitNodeItem(nav = nav, viewModel = model)
+          }
         }
 
         item(key = "divider1") { Lists.SectionDivider() }
@@ -71,13 +79,14 @@ fun ExitNodePicker(
           }
         }
 
-        // TODO: make sure this actually works, and if not, leave it out for now
-        item(key = "allowLANAccess") {
-          Lists.SectionDivider()
+        if (!allowLanAccessMDMDisposition.hiddenFromUser) {
+          item(key = "allowLANAccess") {
+            Lists.SectionDivider()
 
-          Setting.Switch(R.string.allow_lan_access, isOn = allowLANAccess) {
-            LoadingIndicator.start()
-            model.toggleAllowLANAccess { LoadingIndicator.stop() }
+            Setting.Switch(R.string.allow_lan_access, isOn = allowLANAccess) {
+              LoadingIndicator.start()
+              model.toggleAllowLANAccess { LoadingIndicator.stop() }
+            }
           }
         }
       }

--- a/android/src/main/java/com/tailscale/ipn/ui/view/SettingsView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/SettingsView.kt
@@ -26,6 +26,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.tailscale.ipn.BuildConfig
 import com.tailscale.ipn.R
+import com.tailscale.ipn.mdm.MDMSettings
+import com.tailscale.ipn.mdm.ShowHide
 import com.tailscale.ipn.ui.Links
 import com.tailscale.ipn.ui.theme.link
 import com.tailscale.ipn.ui.theme.listItem
@@ -42,6 +44,8 @@ fun SettingsView(settingsNav: SettingsNav, viewModel: SettingsViewModel = viewMo
   val managedByOrganization = viewModel.managedByOrganization.collectAsState().value
   val tailnetLockEnabled = viewModel.tailNetLockEnabled.collectAsState().value
   val corpDNSEnabled = viewModel.corpDNSEnabled.collectAsState().value
+
+  val showTailnetLock = MDMSettings.manageTailnetLock.flow.collectAsState().value
 
   Scaffold(
       topBar = {
@@ -68,14 +72,16 @@ fun SettingsView(settingsNav: SettingsNav, viewModel: SettingsViewModel = viewMo
                   },
               onClick = settingsNav.onNavigateToDNSSettings)
 
-          Lists.ItemDivider()
-          Setting.Text(
-              R.string.tailnet_lock,
-              subtitle =
-                  tailnetLockEnabled?.let {
-                    stringResource(if (it) R.string.enabled else R.string.disabled)
-                  },
-              onClick = settingsNav.onNavigateToTailnetLock)
+          if (showTailnetLock == ShowHide.Show) {
+            Lists.ItemDivider()
+            Setting.Text(
+                R.string.tailnet_lock,
+                subtitle =
+                    tailnetLockEnabled?.let {
+                      stringResource(if (it) R.string.enabled else R.string.disabled)
+                    },
+                onClick = settingsNav.onNavigateToTailnetLock)
+          }
 
           Lists.ItemDivider()
           Setting.Text(R.string.permissions, onClick = settingsNav.onNavigateToPermissions)

--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/IpnViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/IpnViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.tailscale.ipn.App
 import com.tailscale.ipn.IPNReceiver
+import com.tailscale.ipn.mdm.MDMSettings
 import com.tailscale.ipn.ui.localapi.Client
 import com.tailscale.ipn.ui.model.Ipn
 import com.tailscale.ipn.ui.model.IpnLocal
@@ -85,6 +86,12 @@ open class IpnViewModel : ViewModel() {
   // Login/Logout
 
   fun login(options: Ipn.Options = Ipn.Options(), completionHandler: (Result<Unit>) -> Unit = {}) {
+
+    MDMSettings.loginURL.flow.value?.let {
+      Log.d(TAG, "Using MDM derived control URL: $it")
+      loginWithCustomControlURL(it, completionHandler)
+      return
+    }
 
     val loginAction = {
       Client(viewModelScope).startLoginInteractive { result ->


### PR DESCRIPTION
Fixes tailscale/corp#19743

Adds the hooks for the various MDM settings applicable to Android with the exception of the keyExpirationNotice which we'll handle separately.