### PR TITLE
android: fix quick settings tile status

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -46,6 +46,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
                 <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE_PREFERENCES" />
+            </intent-filter>
         </activity>
         <activity
             android:name="ShareActivity"
@@ -95,6 +98,16 @@
             android:permission="android.permission.BIND_VPN_SERVICE">
             <intent-filter>
                 <action android:name="android.net.VpnService" />
+            </intent-filter>
+        </service>
+        <service
+            android:name=".QuickToggleService"
+            android:exported="true"
+            android:icon="@drawable/ic_tile"
+            android:label="@string/tile_name"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
         </service>
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -80,7 +80,6 @@
             </intent-filter>
         </activity>
 
-
         <receiver
             android:name="IPNReceiver"
             android:exported="true">

--- a/android/src/main/java/com/tailscale/ipn/App.kt
+++ b/android/src/main/java/com/tailscale/ipn/App.kt
@@ -5,31 +5,22 @@ package com.tailscale.ipn
 import android.Manifest
 import android.app.Activity
 import android.app.Application
-import android.app.DownloadManager
 import android.app.Fragment
-import android.app.FragmentTransaction
 import android.app.NotificationChannel
 import android.app.PendingIntent
-import android.app.UiModeManager
-import android.content.ContentResolver
 import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
-import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
-import android.content.res.Configuration
 import android.net.ConnectivityManager
 import android.net.LinkProperties
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
-import android.net.Uri
 import android.net.VpnService
 import android.os.Build
 import android.os.Environment
-import android.provider.Settings
 import android.util.Log
-import androidx.browser.customtabs.CustomTabsIntent
 import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
@@ -55,7 +46,7 @@ import java.net.NetworkInterface
 import java.security.GeneralSecurityException
 import java.util.Locale
 
-class App : Application(), libtailscale.AppContext {
+class App : UninitializedApp(), libtailscale.AppContext {
   val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
   companion object {
@@ -63,7 +54,6 @@ class App : Application(), libtailscale.AppContext {
     const val STATUS_NOTIFICATION_ID = 1
     private const val PEER_TAG = "peer"
     private const val FILE_CHANNEL_ID = "tailscale-files"
-    private const val FILE_NOTIFICATION_ID = 2
     private const val TAG = "App"
     private val networkConnectivityRequest =
         NetworkRequest.Builder()
@@ -83,7 +73,7 @@ class App : Application(), libtailscale.AppContext {
      * function to obtain an App reference to make sure the app initializes.
      */
     @JvmStatic
-    fun getApplication(): App {
+    fun get(): App {
       appInstance.initOnce()
       return appInstance
     }
@@ -104,6 +94,7 @@ class App : Application(), libtailscale.AppContext {
   override fun onCreate() {
     super.onCreate()
     appInstance = this
+    setUnprotectedInstance(this)
   }
 
   override fun onTerminate() {
@@ -112,14 +103,14 @@ class App : Application(), libtailscale.AppContext {
     applicationScope.cancel()
   }
 
-  var initialized = false
+  private var isInitialized = false
 
   @Synchronized
   private fun initOnce() {
-    if (initialized) {
+    if (isInitialized) {
       return
     }
-    initialized = true
+    isInitialized = true
 
     val dataDir = this.filesDir.absolutePath
 
@@ -143,7 +134,7 @@ class App : Application(), libtailscale.AppContext {
         val ableToStartVPN = state > Ipn.State.NeedsMachineAuth
         val vpnRunning = state == Ipn.State.Starting || state == Ipn.State.Running
         updateConnStatus(ableToStartVPN, vpnRunning)
-        QuickToggleService.setVPNRunning(this@App, vpnRunning)
+        QuickToggleService.setVPNRunning(vpnRunning)
       }
     }
   }
@@ -182,7 +173,7 @@ class App : Application(), libtailscale.AppContext {
             }
 
             if (dns.updateDNSFromNetwork(sb.toString())) {
-              Libtailscale.onDNSConfigChanged(linkProperties?.getInterfaceName())
+              Libtailscale.onDNSConfigChanged(linkProperties?.interfaceName)
             }
           }
 
@@ -193,12 +184,6 @@ class App : Application(), libtailscale.AppContext {
             }
           }
         })
-  }
-
-  fun startVPN() {
-    val intent = Intent(this, IPNService::class.java)
-    intent.setAction(IPNService.ACTION_REQUEST_VPN)
-    startService(intent)
   }
 
   // encryptToPref a byte array of data using the Jetpack Security
@@ -227,15 +212,17 @@ class App : Application(), libtailscale.AppContext {
         EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM)
   }
 
-  fun updateConnStatus(ableToStartVPN: Boolean, vpnRunning: Boolean) {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
-      return
-    }
-    QuickToggleService.setAbleToStartVPN(this, ableToStartVPN)
+  /*
+   * setAbleToStartVPN remembers whether or not we're able to start the VPN
+   * by storing this in a shared preference. This allows us to check this
+   * value without needing a fully initialized instance of the application.
+   */
+  private fun updateConnStatus(ableToStartVPN: Boolean, vpnRunning: Boolean) {
+    setAbleToStartVPN(ableToStartVPN)
+    QuickToggleService.updateTile()
     Log.d("App", "Set Tile Ready: $ableToStartVPN")
-    val action =
-        if (ableToStartVPN) IPNReceiver.INTENT_DISCONNECT_VPN else IPNReceiver.INTENT_CONNECT_VPN
-    val intent = Intent(this, IPNReceiver::class.java).apply { this.action = action }
+    val action = if (ableToStartVPN) IPNService.ACTION_STOP_VPN else IPNService.ACTION_START_VPN
+    val intent = Intent(this, IPNService::class.java).apply { this.action = action }
     val pendingIntent: PendingIntent =
         PendingIntent.getBroadcast(
             this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
@@ -248,13 +235,6 @@ class App : Application(), libtailscale.AppContext {
         STATUS_CHANNEL_ID,
         pendingIntent,
         STATUS_NOTIFICATION_ID)
-  }
-
-  fun getHostname(): String {
-    val userConfiguredDeviceName = getUserConfiguredDeviceName()
-    if (!userConfiguredDeviceName.isNullOrEmpty()) return userConfiguredDeviceName
-
-    return modelName
   }
 
   override fun getModelName(): String {
@@ -270,133 +250,22 @@ class App : Application(), libtailscale.AppContext {
 
   override fun getOSVersion(): String = Build.VERSION.RELEASE
 
-  // get user defined nickname from Settings
-  // returns null if not available
-  private fun getUserConfiguredDeviceName(): String? {
-    val nameFromSystemDevice = Settings.Secure.getString(contentResolver, "device_name")
-    if (!nameFromSystemDevice.isNullOrEmpty()) return nameFromSystemDevice
-    return null
-  }
-
-  // attachPeer adds a Peer fragment for tracking the Activity
-  // lifecycle.
-  fun attachPeer(act: Activity) {
-    act.runOnUiThread(
-        Runnable {
-          val ft: FragmentTransaction = act.fragmentManager.beginTransaction()
-          ft.add(Peer(), PEER_TAG)
-          ft.commit()
-          act.fragmentManager.executePendingTransactions()
-        })
-  }
-
   override fun isChromeOS(): Boolean {
     return packageManager.hasSystemFeature("android.hardware.type.pc")
   }
 
   fun prepareVPN(act: Activity, reqCode: Int) {
-    act.runOnUiThread(
-        Runnable {
-          val intent: Intent? = VpnService.prepare(act)
-          if (intent == null) {
-            startVPN()
-          } else {
-            startActivityForResult(act, intent, reqCode)
-          }
-        })
-  }
-
-  fun showURL(act: Activity, url: String?) {
-    act.runOnUiThread(
-        Runnable {
-          val builder: CustomTabsIntent.Builder = CustomTabsIntent.Builder()
-          val headerColor = -0xb69b6b
-          builder.setToolbarColor(headerColor)
-          val intent: CustomTabsIntent = builder.build()
-          intent.launchUrl(act, Uri.parse(url))
-        })
-  }
-
-  @get:Throws(Exception::class)
-  val packageCertificate: ByteArray?
-    // getPackageSignatureFingerprint returns the first package signing certificate, if any.
-    get() {
-      val info: PackageInfo
-      info = packageManager.getPackageInfo(packageName, PackageManager.GET_SIGNATURES)
-      for (signature in info.signatures) {
-        return signature.toByteArray()
+    // We do this with UI in case it's our first time starting the VPN.
+    act.runOnUiThread {
+      val prepareIntent = VpnService.prepare(this)
+      if (prepareIntent == null) {
+        // No intent here means that we already have permission to be a VPN.
+        startVPN()
+      } else {
+        // An intent here means that we need to prompt for permission to be a VPN.
+        startActivityForResult(act, prepareIntent, reqCode)
       }
-      return null
     }
-
-  @Throws(IOException::class)
-  fun openUri(uri: String?, mode: String?): Int? {
-    val resolver: ContentResolver = contentResolver
-    return mode?.let { resolver.openFileDescriptor(Uri.parse(uri), it)?.detachFd() }
-  }
-
-  fun deleteUri(uri: String?) {
-    val resolver: ContentResolver = contentResolver
-    resolver.delete(Uri.parse(uri), null, null)
-  }
-
-  fun notifyFile(uri: String?, msg: String?) {
-    val viewIntent: Intent
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-      viewIntent = Intent(Intent.ACTION_VIEW, Uri.parse(uri))
-    } else {
-      // uri is a file:// which is not allowed to be shared outside the app.
-      viewIntent = Intent(DownloadManager.ACTION_VIEW_DOWNLOADS)
-    }
-    val pending: PendingIntent =
-        PendingIntent.getActivity(this, 0, viewIntent, PendingIntent.FLAG_UPDATE_CURRENT)
-    notify(
-        getString(R.string.file_notification),
-        msg,
-        true,
-        FILE_CHANNEL_ID,
-        pending,
-        FILE_NOTIFICATION_ID)
-  }
-
-  fun createNotificationChannel(id: String?, name: String?, importance: Int) {
-    val channel = NotificationChannel(id, name, importance)
-    val nm: NotificationManagerCompat = NotificationManagerCompat.from(this)
-    nm.createNotificationChannel(channel)
-  }
-
-  fun notify(
-      title: String?,
-      message: String?,
-      usesEnabledIcon: Boolean,
-      channel: String,
-      intent: PendingIntent?,
-      notificationID: Int
-  ) {
-    val icon =
-        if (usesEnabledIcon) R.drawable.ic_notification else R.drawable.ic_notification_disabled
-    val builder: NotificationCompat.Builder =
-        NotificationCompat.Builder(this, channel)
-            .setSmallIcon(icon)
-            .setContentTitle(title)
-            .setContentText(message)
-            .setContentIntent(intent)
-            .setAutoCancel(true)
-            .setOnlyAlertOnce(true)
-            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-    val nm: NotificationManagerCompat = NotificationManagerCompat.from(this)
-    if (ActivityCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) !=
-        PackageManager.PERMISSION_GRANTED) {
-      // TODO: Consider calling
-      //    ActivityCompat#requestPermissions
-      // here to request the missing permissions, and then overriding
-      //   public void onRequestPermissionsResult(int requestCode, String[] permissions,
-      //                                          int[] grantResults)
-      // to handle the case where the user grants the permission. See the documentation
-      // for ActivityCompat#requestPermissions for more details.
-      return
-    }
-    nm.notify(notificationID, builder.build())
   }
 
   override fun getInterfacesAsString(): String {
@@ -434,12 +303,7 @@ class App : Application(), libtailscale.AppContext {
     return sb.toString()
   }
 
-  fun isTV(): Boolean {
-    val mm = getSystemService(Context.UI_MODE_SERVICE) as UiModeManager
-    return mm.currentModeType == Configuration.UI_MODE_TYPE_TELEVISION
-  }
-
-  fun prepareDownloadsFolder(): File {
+  private fun prepareDownloadsFolder(): File {
     var downloads = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
 
     try {
@@ -488,5 +352,95 @@ class App : Application(), libtailscale.AppContext {
       Log.d("MDM", "$key is not defined on Android. Throwing NoSuchKeyException.")
       throw MDMSettings.NoSuchKeyException()
     }
+  }
+}
+
+/**
+ * UninitializedApp contains all of the methods of App that can be used without having to initialize
+ * the Go backend. This is useful when you want to access functions on the App without creating side
+ * effects from starting the Go backend (such as launching the VPN).
+ */
+open class UninitializedApp : Application() {
+  companion object {
+    // Key for shared preference that tracks whether or not we're able to start
+    // the VPN (i.e. we're logged in and machine is authorized).
+    private const val ABLE_TO_START_VPN_KEY = "ableToStartVPN"
+
+    // File for shared preferences that are not encrypted.
+    private const val UNENCRYPTED_PREFERENCES = "unencrypted"
+
+    private lateinit var appInstance: UninitializedApp
+
+    @JvmStatic
+    fun get(): UninitializedApp {
+      return appInstance
+    }
+  }
+
+  protected fun setUnprotectedInstance(instance: UninitializedApp) {
+    appInstance = instance
+  }
+
+  protected fun setAbleToStartVPN(rdy: Boolean) {
+    getUnencryptedPrefs().edit().putBoolean(ABLE_TO_START_VPN_KEY, rdy).apply()
+  }
+
+  /** This function can be called without initializing the App. */
+  fun isAbleToStartVPN(): Boolean {
+    return getUnencryptedPrefs().getBoolean(ABLE_TO_START_VPN_KEY, false)
+  }
+
+  private fun getUnencryptedPrefs(): SharedPreferences {
+    return getSharedPreferences(UNENCRYPTED_PREFERENCES, MODE_PRIVATE)
+  }
+
+  fun startVPN() {
+    val intent = Intent(this, IPNService::class.java).apply { action = IPNService.ACTION_START_VPN }
+    startService(intent)
+  }
+
+  fun stopVPN() {
+    val intent = Intent(this, IPNService::class.java).apply { action = IPNService.ACTION_STOP_VPN }
+    startService(intent)
+  }
+
+  fun createNotificationChannel(id: String?, name: String?, importance: Int) {
+    val channel = NotificationChannel(id, name, importance)
+    val nm: NotificationManagerCompat = NotificationManagerCompat.from(this)
+    nm.createNotificationChannel(channel)
+  }
+
+  fun notify(
+      title: String?,
+      message: String?,
+      usesEnabledIcon: Boolean,
+      channel: String,
+      intent: PendingIntent?,
+      notificationID: Int
+  ) {
+    val icon =
+        if (usesEnabledIcon) R.drawable.ic_notification else R.drawable.ic_notification_disabled
+    val builder: NotificationCompat.Builder =
+        NotificationCompat.Builder(this, channel)
+            .setSmallIcon(icon)
+            .setContentTitle(title)
+            .setContentText(message)
+            .setContentIntent(intent)
+            .setAutoCancel(true)
+            .setOnlyAlertOnce(true)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+    val nm: NotificationManagerCompat = NotificationManagerCompat.from(this)
+    if (ActivityCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) !=
+        PackageManager.PERMISSION_GRANTED) {
+      // TODO: Consider calling
+      //    ActivityCompat#requestPermissions
+      // here to request the missing permissions, and then overriding
+      //   public void onRequestPermissionsResult(int requestCode, String[] permissions,
+      //                                          int[] grantResults)
+      // to handle the case where the user grants the permission. See the documentation
+      // for ActivityCompat#requestPermissions for more details.
+      return
+    }
+    nm.notify(notificationID, builder.build())
   }
 }

--- a/android/src/main/java/com/tailscale/ipn/App.kt
+++ b/android/src/main/java/com/tailscale/ipn/App.kt
@@ -70,7 +70,7 @@ class App : Application(), libtailscale.AppContext {
             .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
             .addCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN)
             .build()
-    lateinit var appInstance: App
+    private lateinit var appInstance: App
 
     @JvmStatic
     fun startActivityForResult(act: Activity, intent: Intent?, request: Int) {
@@ -78,8 +78,13 @@ class App : Application(), libtailscale.AppContext {
       f.startActivityForResult(intent, request)
     }
 
+    /**
+     * Initializes the app (if necessary) and returns the singleton app instance. Always use this
+     * function to obtain an App reference to make sure the app initializes.
+     */
     @JvmStatic
     fun getApplication(): App {
+      appInstance.initOnce()
       return appInstance
     }
   }
@@ -98,6 +103,24 @@ class App : Application(), libtailscale.AppContext {
 
   override fun onCreate() {
     super.onCreate()
+    appInstance = this
+  }
+
+  override fun onTerminate() {
+    super.onTerminate()
+    Notifier.stop()
+    applicationScope.cancel()
+  }
+
+  var initialized = false
+
+  @Synchronized
+  private fun initOnce() {
+    if (initialized) {
+      return
+    }
+    initialized = true
+
     val dataDir = this.filesDir.absolutePath
 
     // Set this to enable direct mode for taildrop whereby downloads will be saved directly
@@ -105,7 +128,6 @@ class App : Application(), libtailscale.AppContext {
     // an app local directory "Taildrop" if we cannot create that.  This mode does not support
     // user notifications for incoming files.
     val directFileDir = this.prepareDownloadsFolder()
-
     app = Libtailscale.start(dataDir, directFileDir.absolutePath, this)
     Request.setApp(app)
     Notifier.setApp(app)
@@ -116,16 +138,14 @@ class App : Application(), libtailscale.AppContext {
         STATUS_CHANNEL_ID, "VPN Status", NotificationManagerCompat.IMPORTANCE_LOW)
     createNotificationChannel(
         FILE_CHANNEL_ID, "File transfers", NotificationManagerCompat.IMPORTANCE_DEFAULT)
-    appInstance = this
     applicationScope.launch {
-      Notifier.connStatus.collect { connStatus -> updateConnStatus(connStatus) }
+      Notifier.state.collect { state ->
+        val ableToStartVPN = state > Ipn.State.NeedsMachineAuth
+        val vpnRunning = state == Ipn.State.Starting || state == Ipn.State.Running
+        updateConnStatus(ableToStartVPN, vpnRunning)
+        QuickToggleService.setVPNRunning(this@App, vpnRunning)
+      }
     }
-  }
-
-  override fun onTerminate() {
-    super.onTerminate()
-    Notifier.stop()
-    applicationScope.cancel()
   }
 
   fun setWantRunning(wantRunning: Boolean) {
@@ -207,24 +227,27 @@ class App : Application(), libtailscale.AppContext {
         EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM)
   }
 
-  fun updateConnStatus(ready: Boolean) {
+  fun updateConnStatus(ableToStartVPN: Boolean, vpnRunning: Boolean) {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
       return
     }
-    QuickToggleService.setReady(this, ready)
-    Log.d("App", "Set Tile Ready: $ready")
-    val action = if (ready) IPNReceiver.INTENT_DISCONNECT_VPN else IPNReceiver.INTENT_CONNECT_VPN
+    QuickToggleService.setAbleToStartVPN(this, ableToStartVPN)
+    Log.d("App", "Set Tile Ready: $ableToStartVPN")
+    val action =
+        if (ableToStartVPN) IPNReceiver.INTENT_DISCONNECT_VPN else IPNReceiver.INTENT_CONNECT_VPN
     val intent = Intent(this, IPNReceiver::class.java).apply { this.action = action }
     val pendingIntent: PendingIntent =
         PendingIntent.getBroadcast(
             this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
-    if (ready) {
-      startVPN()
-    }
     val notificationMessage =
-        if (ready) getString(R.string.connected) else getString(R.string.not_connected)
+        if (vpnRunning) getString(R.string.connected) else getString(R.string.not_connected)
     notify(
-        "Tailscale", notificationMessage, ready, STATUS_CHANNEL_ID, pendingIntent, STATUS_NOTIFICATION_ID)
+        "Tailscale",
+        notificationMessage,
+        vpnRunning,
+        STATUS_CHANNEL_ID,
+        pendingIntent,
+        STATUS_NOTIFICATION_ID)
   }
 
   fun getHostname(): String {
@@ -328,7 +351,12 @@ class App : Application(), libtailscale.AppContext {
     val pending: PendingIntent =
         PendingIntent.getActivity(this, 0, viewIntent, PendingIntent.FLAG_UPDATE_CURRENT)
     notify(
-        getString(R.string.file_notification), msg, true, FILE_CHANNEL_ID, pending, FILE_NOTIFICATION_ID)
+        getString(R.string.file_notification),
+        msg,
+        true,
+        FILE_CHANNEL_ID,
+        pending,
+        FILE_NOTIFICATION_ID)
   }
 
   fun createNotificationChannel(id: String?, name: String?, importance: Int) {
@@ -345,7 +373,8 @@ class App : Application(), libtailscale.AppContext {
       intent: PendingIntent?,
       notificationID: Int
   ) {
-    val icon = if (usesEnabledIcon) R.drawable.ic_notification else R.drawable.ic_notification_disabled
+    val icon =
+        if (usesEnabledIcon) R.drawable.ic_notification else R.drawable.ic_notification_disabled
     val builder: NotificationCompat.Builder =
         NotificationCompat.Builder(this, channel)
             .setSmallIcon(icon)

--- a/android/src/main/java/com/tailscale/ipn/IPNReceiver.java
+++ b/android/src/main/java/com/tailscale/ipn/IPNReceiver.java
@@ -12,6 +12,9 @@ import androidx.work.WorkManager;
 
 import java.util.Objects;
 
+/**
+ * IPNReceiver allows external applications to start the VPN.
+ */
 public class IPNReceiver extends BroadcastReceiver {
 
     public static final String INTENT_CONNECT_VPN = "com.tailscale.ipn.CONNECT_VPN";

--- a/android/src/main/java/com/tailscale/ipn/MainActivity.kt
+++ b/android/src/main/java/com/tailscale/ipn/MainActivity.kt
@@ -99,7 +99,7 @@ class MainActivity : ComponentActivity() {
     super.onCreate(savedInstanceState)
 
     // grab app to make sure it initializes
-    App.getApplication()
+    App.get()
 
     // (jonathan) TODO: Force the app to be portrait on small screens until we have
     // proper landscape layout support
@@ -234,7 +234,7 @@ class MainActivity : ComponentActivity() {
     lifecycleScope.launch {
       Notifier.state.collect { state ->
         if (state > Ipn.State.Stopped) {
-          App.getApplication().prepareVPN(this@MainActivity, RequestCodes.requestPrepareVPN)
+          App.get().prepareVPN(this@MainActivity, RequestCodes.requestPrepareVPN)
         }
       }
     }
@@ -276,7 +276,7 @@ class MainActivity : ComponentActivity() {
   private fun login(urlString: String) {
     // Launch coroutine to listen for state changes. When the user completes login, relaunch
     // MainActivity to bring the app back to focus.
-    App.getApplication().applicationScope.launch {
+    App.get().applicationScope.launch {
       try {
         Notifier.state.collect { state ->
           if (state > Ipn.State.NeedsMachineAuth) {
@@ -317,9 +317,7 @@ class MainActivity : ComponentActivity() {
     super.onResume()
     val restrictionsManager =
         this.getSystemService(Context.RESTRICTIONS_SERVICE) as RestrictionsManager
-    lifecycleScope.launch(Dispatchers.IO) {
-      MDMSettings.update(App.getApplication(), restrictionsManager)
-    }
+    lifecycleScope.launch(Dispatchers.IO) { MDMSettings.update(App.get(), restrictionsManager) }
   }
 
   override fun onStart() {
@@ -334,9 +332,7 @@ class MainActivity : ComponentActivity() {
     super.onStop()
     val restrictionsManager =
         this.getSystemService(Context.RESTRICTIONS_SERVICE) as RestrictionsManager
-    lifecycleScope.launch(Dispatchers.IO) {
-      MDMSettings.update(App.getApplication(), restrictionsManager)
-    }
+    lifecycleScope.launch(Dispatchers.IO) { MDMSettings.update(App.get(), restrictionsManager) }
   }
 
   private fun requestVpnPermission() {

--- a/android/src/main/java/com/tailscale/ipn/MainActivity.kt
+++ b/android/src/main/java/com/tailscale/ipn/MainActivity.kt
@@ -11,12 +11,10 @@ import android.content.RestrictionsManager
 import android.content.pm.ActivityInfo
 import android.content.res.Configuration.SCREENLAYOUT_SIZE_LARGE
 import android.content.res.Configuration.SCREENLAYOUT_SIZE_MASK
-import android.net.Uri
 import android.net.VpnService
 import android.os.Bundle
 import android.provider.Settings
 import android.util.Log
-import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.ActivityResultLauncher
@@ -99,6 +97,9 @@ class MainActivity : ComponentActivity() {
   @SuppressLint("SourceLockedOrientationActivity")
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+
+    // grab app to make sure it initializes
+    App.getApplication()
 
     // (jonathan) TODO: Force the app to be portrait on small screens until we have
     // proper landscape layout support
@@ -231,9 +232,10 @@ class MainActivity : ComponentActivity() {
       }
     }
     lifecycleScope.launch {
-      Notifier.readyToPrepareVPN.collect { isReady ->
-        if (isReady)
-            App.getApplication().prepareVPN(this@MainActivity, RequestCodes.requestPrepareVPN)
+      Notifier.state.collect { state ->
+        if (state > Ipn.State.Stopped) {
+          App.getApplication().prepareVPN(this@MainActivity, RequestCodes.requestPrepareVPN)
+        }
       }
     }
   }
@@ -351,9 +353,9 @@ class MainActivity : ComponentActivity() {
 
   private fun openApplicationSettings() {
     val intent =
-    Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
-      putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
-  }
+        Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
+          putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
+        }
     intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
     startActivity(intent)
   }

--- a/android/src/main/java/com/tailscale/ipn/Peer.java
+++ b/android/src/main/java/com/tailscale/ipn/Peer.java
@@ -18,9 +18,9 @@ public class Peer extends Fragment {
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (requestCode == RequestCodes.requestPrepareVPN) {
             if (resultCode == resultOK) {
-                App.getApplication().startVPN();
+                UninitializedApp.get().startVPN();
             } else {
-                App.getApplication().setWantRunning(false);
+                App.get().setWantRunning(false);
                 // notify VPN revoked
             }
         }

--- a/android/src/main/java/com/tailscale/ipn/StopVPNWorker.java
+++ b/android/src/main/java/com/tailscale/ipn/StopVPNWorker.java
@@ -5,9 +5,13 @@ package com.tailscale.ipn;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
 import androidx.work.Worker;
 import androidx.work.WorkerParameters;
 
+/**
+ * A worker that exists to support IPNReceiver.
+ */
 public final class StopVPNWorker extends Worker {
 
     public StopVPNWorker(
@@ -16,9 +20,10 @@ public final class StopVPNWorker extends Worker {
         super(appContext, workerParams);
     }
 
+    @NonNull
     @Override
     public Result doWork() {
-        App.getApplication().setWantRunning(false);
+        UninitializedApp.get().stopVPN();
         return Result.success();
     }
 }

--- a/android/src/main/java/com/tailscale/ipn/mdm/MDMSettingsDefinitions.kt
+++ b/android/src/main/java/com/tailscale/ipn/mdm/MDMSettingsDefinitions.kt
@@ -44,7 +44,7 @@ class AlwaysNeverUserDecidesMDMSetting(key: String, localizedTitle: String) :
   override fun getFrom(bundle: Bundle?, app: App): AlwaysNeverUserDecides {
     val storedString =
         bundle?.getString(key)
-            ?: App.getApplication().getEncryptedPrefs().getString(key, null)
+            ?: App.get().getEncryptedPrefs().getString(key, null)
             ?: "user-decides"
     return when (storedString) {
       "always" -> {
@@ -64,9 +64,7 @@ class ShowHideMDMSetting(key: String, localizedTitle: String) :
     MDMSetting<ShowHide>(ShowHide.Show, key, localizedTitle) {
   override fun getFrom(bundle: Bundle?, app: App): ShowHide {
     val storedString =
-        bundle?.getString(key)
-            ?: App.getApplication().getEncryptedPrefs().getString(key, null)
-            ?: "show"
+        bundle?.getString(key) ?: App.get().getEncryptedPrefs().getString(key, null) ?: "show"
     return when (storedString) {
       "hide" -> {
         ShowHide.Hide

--- a/android/src/main/java/com/tailscale/ipn/ui/notifier/Notifier.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/notifier/Notifier.kt
@@ -30,10 +30,6 @@ object Notifier {
   private val TAG = Notifier::class.simpleName
   private val decoder = Json { ignoreUnknownKeys = true }
 
-  // Global App State
-  val connStatus: StateFlow<Boolean> = MutableStateFlow(false)
-  val readyToPrepareVPN: StateFlow<Boolean> = MutableStateFlow(false)
-
   // General IPN Bus State
   val state: StateFlow<Ipn.State> = MutableStateFlow(Ipn.State.NoState)
   val netmap: StateFlow<Netmap.NetworkMap?> = MutableStateFlow(null)
@@ -80,10 +76,6 @@ object Notifier {
             notify.FilesWaiting?.let(filesWaiting::set)
             notify.IncomingFiles?.let(incomingFiles::set)
           }
-      state.collect { currstate ->
-        readyToPrepareVPN.set(currstate > Ipn.State.Stopped)
-        connStatus.set(currstate > Ipn.State.Stopped)
-      }
     }
   }
 

--- a/android/src/main/java/com/tailscale/ipn/ui/util/AndroidTVUtil.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/util/AndroidTVUtil.kt
@@ -14,8 +14,10 @@ import com.tailscale.ipn.ui.util.AndroidTVUtil.isAndroidTV
 
 object AndroidTVUtil {
   fun isAndroidTV(): Boolean {
-    return (App.appInstance.packageManager.hasSystemFeature(PackageManager.FEATURE_TELEVISION) ||
-        App.appInstance.packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK))
+    return (App.getApplication()
+        .packageManager
+        .hasSystemFeature(PackageManager.FEATURE_TELEVISION) ||
+        App.getApplication().packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK))
   }
 }
 

--- a/android/src/main/java/com/tailscale/ipn/ui/util/AndroidTVUtil.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/util/AndroidTVUtil.kt
@@ -9,15 +9,14 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
-import com.tailscale.ipn.App
+import com.tailscale.ipn.UninitializedApp
 import com.tailscale.ipn.ui.util.AndroidTVUtil.isAndroidTV
 
 object AndroidTVUtil {
   fun isAndroidTV(): Boolean {
-    return (App.getApplication()
-        .packageManager
-        .hasSystemFeature(PackageManager.FEATURE_TELEVISION) ||
-        App.getApplication().packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK))
+    val pm = UninitializedApp.get().packageManager
+    return (pm.hasSystemFeature(PackageManager.FEATURE_TELEVISION) ||
+        pm.hasSystemFeature(PackageManager.FEATURE_LEANBACK))
   }
 }
 

--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/IpnViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/IpnViewModel.kt
@@ -3,12 +3,10 @@
 
 package com.tailscale.ipn.ui.viewModel
 
-import android.content.Intent
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.tailscale.ipn.App
-import com.tailscale.ipn.IPNReceiver
+import com.tailscale.ipn.UninitializedApp
 import com.tailscale.ipn.mdm.MDMSettings
 import com.tailscale.ipn.ui.localapi.Client
 import com.tailscale.ipn.ui.model.Ipn
@@ -70,17 +68,11 @@ open class IpnViewModel : ViewModel() {
   }
 
   fun startVPN() {
-    val context = App.getApplication().applicationContext
-    val intent = Intent(context, IPNReceiver::class.java)
-    intent.action = IPNReceiver.INTENT_CONNECT_VPN
-    context.sendBroadcast(intent)
+    UninitializedApp.get().startVPN()
   }
 
-  fun stopVPN() {
-    val context = App.getApplication().applicationContext
-    val intent = Intent(context, IPNReceiver::class.java)
-    intent.action = IPNReceiver.INTENT_DISCONNECT_VPN
-    context.sendBroadcast(intent)
+  private fun stopVPN() {
+    UninitializedApp.get().stopVPN()
   }
 
   // Login/Logout

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -242,4 +242,7 @@
     <string name="welcome2">All connections are device-to-device, so we never see your data. We collect and use your email address and name, as well as your device name, OS version, and IP address in order to help you to connect your devices and manage your settings. We log when you are connected to your network.</string>
     <string name="scan_to_connect_to_your_tailnet">Scan this QR code to log in to your tailnet</string>
 
+    <!-- Strings for the IPNReceiver -->
+    <string name="title_connection_failed">Tailscale Connection Failed</string>
+    <string name="body_open_tailscale">Tap here to open Tailscale.</string>
 </resources>


### PR DESCRIPTION
https://github.com/tailscale/tailscale-android/pull/358 updated the Quick Settings tile to only depend on ipn state. This was only partially correct in the sense that we made changes to only check for whether the state was > stopped and not whether Tailscale was on.

This checks for two states, whether Tailscale is on, and whether the tile is ready to be used. The former requires ipn state to be >= Starting, and the latter checks whether ipn state is > RequiresMachineAuth. Tile readiness determines whether an intent is to open MainActivity or whether an intent to connect/disconnect VPN is sent. Whether Tailscale is on or off determines whether the tile status is active or not.

Updates tailscale/tailscale#11920