### PR TITLE
android: lazily initialize App to avoid starting Tailscale when unnec…

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/IPNService.kt
+++ b/android/src/main/java/com/tailscale/ipn/IPNService.kt
@@ -8,8 +8,6 @@ import android.content.pm.PackageManager
 import android.net.VpnService
 import android.os.Build
 import android.system.OsConstants
-import androidx.core.app.NotificationCompat
-import androidx.core.app.NotificationManagerCompat
 import libtailscale.Libtailscale
 import java.util.UUID
 
@@ -21,7 +19,6 @@ open class IPNService : VpnService(), libtailscale.IPNService {
   }
 
   override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-    val app = applicationContext as App
     if (intent != null && "android.net.VpnService" == intent.action) {
       // Start VPN and connect to it due to Always-on VPN
       val i = Intent(IPNReceiver.INTENT_CONNECT_VPN)
@@ -30,15 +27,14 @@ open class IPNService : VpnService(), libtailscale.IPNService {
       sendBroadcast(i)
     }
     Libtailscale.requestVPN(this)
-    app.setWantRunning(true)
+    App.getApplication().setWantRunning(true)
     return START_STICKY
   }
 
   override public fun close() {
     stopForeground(true)
     Libtailscale.serviceDisconnect(this)
-    val app = applicationContext as App
-    app.setWantRunning(false)
+    App.getApplication().setWantRunning(false)
   }
 
   override fun onDestroy() {

--- a/android/src/main/java/com/tailscale/ipn/MainActivity.kt
+++ b/android/src/main/java/com/tailscale/ipn/MainActivity.kt
@@ -11,12 +11,10 @@ import android.content.RestrictionsManager
 import android.content.pm.ActivityInfo
 import android.content.res.Configuration.SCREENLAYOUT_SIZE_LARGE
 import android.content.res.Configuration.SCREENLAYOUT_SIZE_MASK
-import android.net.Uri
 import android.net.VpnService
 import android.os.Bundle
 import android.provider.Settings
 import android.util.Log
-import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.ActivityResultLauncher
@@ -349,9 +347,9 @@ class MainActivity : ComponentActivity() {
 
   private fun openApplicationSettings() {
     val intent =
-    Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
-      putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
-  }
+        Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
+          putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
+        }
     intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
     startActivity(intent)
   }

--- a/android/src/main/java/com/tailscale/ipn/ui/util/AndroidTVUtil.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/util/AndroidTVUtil.kt
@@ -14,8 +14,10 @@ import com.tailscale.ipn.ui.util.AndroidTVUtil.isAndroidTV
 
 object AndroidTVUtil {
   fun isAndroidTV(): Boolean {
-    return (App.appInstance.packageManager.hasSystemFeature(PackageManager.FEATURE_TELEVISION) ||
-        App.appInstance.packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK))
+    return (App.getApplication()
+        .packageManager
+        .hasSystemFeature(PackageManager.FEATURE_TELEVISION) ||
+        App.getApplication().packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK))
   }
 }
 


### PR DESCRIPTION
…essary

For example, when viewing the QuickSettings tile, there's no need to start Tailscale's backend.

Updates #cleanup

Note - this does not solve the issue with Tailscale wanting to connect whenever you open up the activity, but it keeps the QuickSettings tile from starting the backend. That's good both because it keeps it from connecting, and also because it saves resources since we're not starting up background activity just for displaying the Quick Settings tile.