### PR TITLE
android: temporarily remove quick settings tile

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -46,9 +46,6 @@
                 <category android:name="android.intent.category.LAUNCHER" />
                 <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
             </intent-filter>
-            <intent-filter>
-                <action android:name="android.service.quicksettings.action.QS_TILE_PREFERENCES" />
-            </intent-filter>
         </activity>
         <activity
             android:name="ShareActivity"
@@ -99,16 +96,6 @@
             android:permission="android.permission.BIND_VPN_SERVICE">
             <intent-filter>
                 <action android:name="android.net.VpnService" />
-            </intent-filter>
-        </service>
-        <service
-            android:name=".QuickToggleService"
-            android:exported="true"
-            android:icon="@drawable/ic_tile"
-            android:label="@string/tile_name"
-            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
-            <intent-filter>
-                <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
         </service>
 


### PR DESCRIPTION
This is a workaround for tailscale/corp#19860 until the root cause can be sorted out.

Updates tailscale/corp#19860