### PR TITLE
android/ui: fix theming for the exit node picker button

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/ui/theme/Theme.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/theme/Theme.kt
@@ -345,11 +345,19 @@ val ColorScheme.exitNodeToggleButton: ButtonColors
   @Composable
   get() {
     val defaults = ButtonDefaults.buttonColors()
-    return ButtonColors(
-        containerColor = Color(0xFF4B70CC), // blue-500
-        contentColor = Color(0xFFFFFFFF), // white
-        disabledContainerColor = defaults.disabledContainerColor,
-        disabledContentColor = defaults.disabledContentColor)
+    return if (isSystemInDarkTheme()) {
+      ButtonColors(
+          containerColor = Color(0xFF444342), // grey-600
+          contentColor = Color(0xFFFFFFFF), // white
+          disabledContainerColor = defaults.disabledContainerColor,
+          disabledContentColor = defaults.disabledContentColor)
+    } else {
+      ButtonColors(
+          containerColor = Color(0xFFEDEBEA), // grey-300
+          contentColor = Color(0xFF000000), // black
+          disabledContainerColor = defaults.disabledContainerColor,
+          disabledContentColor = defaults.disabledContentColor)
+    }
   }
 
 val ColorScheme.disabled: Color


### PR DESCRIPTION
Fixes tailscale/corp#19881

Exit node picker button is now grey-200 in light mode and grey-700 in dark mode for the disabled state.

After:
![Screenshot 2024-05-09 at 9 28 31 AM](https://github.com/tailscale/tailscale-android/assets/779591/6f1cdd52-6237-4d48-82c0-36126674db04)

![Screenshot 2024-05-09 at 9 27 45 AM](https://github.com/tailscale/tailscale-android/assets/779591/bef7cbdf-949b-48dd-8ed4-38c052b6c3cd)
