### PR TITLE
android: only navigate to main if navController is initialized

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/MainActivity.kt
+++ b/android/src/main/java/com/tailscale/ipn/MainActivity.kt
@@ -265,7 +265,9 @@ class MainActivity : ComponentActivity() {
   override fun onNewIntent(intent: Intent?) {
     super.onNewIntent(intent)
     if (intent?.getBooleanExtra(START_AT_ROOT, false) == true) {
-      navController.popBackStack(route = "main", inclusive = false)
+      if (this::navController.isInitialized) {
+        navController.popBackStack(route = "main", inclusive = false)
+      }
     }
   }
 


### PR DESCRIPTION
Updates #cleanup

Fixes crashes like this one

![image](https://github.com/tailscale/tailscale-android/assets/5000654/c6d32734-121e-4c77-ac86-7e3a41d569b1)
