### PR TITLE
android: make disconnected notification non-foreground

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/IPNService.kt
+++ b/android/src/main/java/com/tailscale/ipn/IPNService.kt
@@ -39,8 +39,9 @@ open class IPNService : VpnService(), libtailscale.IPNService {
         }
         "android.net.VpnService" -> {
           // This means we were started by Android due to Always On VPN.
-          // We don't show a foreground notification because we weren't
+          // We show a non-foreground notification because we weren't
           // started as a foreground service.
+          App.get().notifyStatus(true)
           App.get().setWantRunning(true)
           Libtailscale.requestVPN(this)
           START_STICKY
@@ -49,6 +50,7 @@ open class IPNService : VpnService(), libtailscale.IPNService {
           // This means that we were restarted after the service was killed
           // (potentially due to OOM).
           if (UninitializedApp.get().isAbleToStartVPN()) {
+            showForegroundNotification()
             App.get()
             Libtailscale.requestVPN(this)
             START_STICKY
@@ -59,7 +61,7 @@ open class IPNService : VpnService(), libtailscale.IPNService {
       }
 
   override fun close() {
-    stopForeground(true)
+    stopForeground(STOP_FOREGROUND_REMOVE)
     Libtailscale.serviceDisconnect(this)
   }
 


### PR DESCRIPTION
Follow-up to https://github.com/tailscale/tailscale-android/pull/389
Use foreground notifications only when the service was started as a foreground service

Updates #cleanup