### PR TITLE
android: set wantRunning to true when started from Always On VPN

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/IPNService.kt
+++ b/android/src/main/java/com/tailscale/ipn/IPNService.kt
@@ -39,9 +39,9 @@ open class IPNService : VpnService(), libtailscale.IPNService {
         }
         "android.net.VpnService" -> {
           // This means we were started by Android due to Always On VPN.
-          // Get the application to make sure it's been initialized, then
-          // request the VPN.
-          App.get()
+          // We don't show a foreground notification because we weren't
+          // started as a foreground service.
+          App.get().setWantRunning(true)
           Libtailscale.requestVPN(this)
           START_STICKY
         }


### PR DESCRIPTION
This way, even if the VPN wasn't previously manually enabled, it'll still turn on after reboot

Updates #cleanup