### PR TITLE
android/docker: update makefile and dockerfile for build automation

### DIFF
--- a/docker/DockerFile.amd64-build
+++ b/docker/DockerFile.amd64-build
@@ -1,0 +1,47 @@
+# This is a Dockerfile for creating a build environment for
+# tailscale-android.
+
+FROM --platform=linux/amd64 eclipse-temurin:20-jdk
+
+# To enable running android tools such as aapt
+RUN apt-get update && apt-get -y upgrade
+RUN apt-get install -y libz1 libstdc++6 unzip
+# For Go:
+RUN apt-get -y --no-install-recommends install curl gcc
+RUN apt-get -y --no-install-recommends install ca-certificates libc6-dev git
+
+RUN apt-get -y install make
+
+RUN mkdir -p build
+ENV HOME /build
+
+# Make android sdk location, the later make step will populate it.
+RUN mkdir android-sdk
+ENV ANDROID_HOME $HOME/android-sdk
+ENV ANDROID_SDK_ROOT $ANDROID_HOME
+ENV PATH $PATH:$HOME/bin:$ANDROID_HOME/platform-tools
+
+# We need some version of Go new enough to support the "embed" package
+# to run "go run tailscale.com/cmd/printdep" to figure out which Tailscale Go
+# version we need later, but otherwise this toolchain isn't used:
+RUN curl -L https://go.dev/dl/go1.22.0.linux-amd64.tar.gz | tar -C /usr/local -zxv
+RUN ln -s /usr/local/go/bin/go /usr/bin
+
+RUN mkdir -p $HOME/tailscale-android
+RUN git config --global --add safe.directory $HOME/tailscale-android
+WORKDIR $HOME/tailscale-android
+
+COPY Makefile Makefile
+
+# Get android sdk, ndk, and rest of the stuff needed to build the android app.
+RUN make androidsdk
+
+# Preload Gradle
+COPY android/gradlew android/gradlew
+COPY android/gradle android/gradle
+RUN ./android/gradlew
+
+# Build the android app
+CMD make clean
+CMD make release
+

--- a/docker/DockerFile.amd64-shell
+++ b/docker/DockerFile.amd64-shell
@@ -31,8 +31,8 @@ RUN mkdir -p $HOME/tailscale-android
 RUN git config --global --add safe.directory $HOME/tailscale-android
 WORKDIR $HOME/tailscale-android
 
-# Preload Android SDK
 COPY Makefile Makefile
+
 # Get android sdk, ndk, and rest of the stuff needed to build the android app.
 RUN make androidsdk
 
@@ -41,4 +41,7 @@ COPY android/gradlew android/gradlew
 COPY android/gradle android/gradle
 RUN ./android/gradlew
 
+# Run a shell
 CMD /bin/bash
+
+


### PR DESCRIPTION
Updates tailsale/corp#19670

Added a dockerfile where can run full release build in addition to  dropping into a shell.

The build will now look for JKS_PASSWORD in the environment for completing the signing step without user interaction.

Several smaller recipes added to the makefile for building the docker builder image, running and cleaning it up.