### PR TITLE
android/ui: unhide accounts if VPN is prepared

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/IpnViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/IpnViewModel.kt
@@ -3,9 +3,11 @@
 
 package com.tailscale.ipn.ui.viewModel
 
+import android.net.VpnService
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.tailscale.ipn.App
 import com.tailscale.ipn.UninitializedApp
 import com.tailscale.ipn.mdm.MDMSettings
 import com.tailscale.ipn.ui.localapi.Client
@@ -36,6 +38,16 @@ open class IpnViewModel : ViewModel() {
   private var selfNodeUserId: UserID? = null
 
   init {
+    // Check if the user has granted permission yet.
+    if (!vpnPrepared.value) {
+      val vpnIntent = VpnService.prepare(App.get())
+      if (vpnIntent != null) {
+        setVpnPrepared(false)
+      } else {
+        setVpnPrepared(true)
+      }
+    }
+
     viewModelScope.launch {
       Notifier.state.collect {
         // Reload the user profiles on all state transitions to ensure loggedInUser is correct

--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/MainViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/MainViewModel.kt
@@ -54,7 +54,6 @@ class MainViewModel : IpnViewModel() {
   private val peerCategorizer = PeerCategorizer()
 
   init {
-
     viewModelScope.launch {
       var previousState: State? = null
 
@@ -108,6 +107,8 @@ class MainViewModel : IpnViewModel() {
     val vpnIntent = VpnService.prepare(App.get())
     if (vpnIntent != null) {
       vpnPermissionLauncher?.launch(vpnIntent)
+    } else {
+      setVpnPrepared(true)
     }
   }
 
@@ -127,6 +128,7 @@ class MainViewModel : IpnViewModel() {
   }
 
   fun setVpnPermissionLauncher(launcher: ActivityResultLauncher<Intent>) {
+    // No intent means we're already authorized
     vpnPermissionLauncher = launcher
   }
 }


### PR DESCRIPTION
Updates tailscale/tailscale#12148

There was a small bug where we weren't rechecking the vpn permissions so the FUS would never show.  We'll now do that in the view model base case on initialization and again on vpn-enable.