### PR TITLE
android: start VPN after preparing VPN

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/MainActivity.kt
+++ b/android/src/main/java/com/tailscale/ipn/MainActivity.kt
@@ -117,12 +117,13 @@ class MainActivity : ComponentActivity() {
           if (granted) {
             Log.d("VpnPermission", "VPN permission granted")
             viewModel.setVpnPrepared(true)
+            App.get().startVPN()
           } else {
             Log.d("VpnPermission", "VPN permission denied")
             viewModel.setVpnPrepared(false)
           }
         }
-        viewModel.setVpnPermissionLauncher(vpnPermissionLauncher)
+    viewModel.setVpnPermissionLauncher(vpnPermissionLauncher)
 
     setContent {
       AppTheme {

--- a/android/src/main/java/com/tailscale/ipn/ui/view/MainView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/MainView.kt
@@ -109,7 +109,7 @@ fun MainView(
       Column(
           modifier = Modifier.fillMaxWidth().padding(paddingInsets),
           verticalArrangement = Arrangement.Center) {
-            // Assume VPN has been prepared. Whether or not it has been prepared cannot be known
+            // Assume VPN has been prepared for optimistic UI. Whether or not it has been prepared cannot be known
             // until permission has been granted to prepare the VPN.
             val isPrepared by viewModel.vpnPrepared.collectAsState(initial = true)
             val isOn by viewModel.vpnToggleState.collectAsState(initial = false)
@@ -169,6 +169,8 @@ fun MainView(
               Ipn.State.Running -> {
 
                 PromptPermissionsIfNecessary()
+
+                viewModel.showVPNPermissionLauncherIfUnauthorized()
 
                 if (showKeyExpiry) {
                   ExpiryNotification(netmap = netmap, action = { viewModel.login() })

--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/MainViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/MainViewModel.kt
@@ -109,6 +109,7 @@ class MainViewModel : IpnViewModel() {
       vpnPermissionLauncher?.launch(vpnIntent)
     } else {
       setVpnPrepared(true)
+      startVPN()
     }
   }
 


### PR DESCRIPTION
https://github.com/tailscale/tailscale-android/pull/398 introduced a bug where we were not calling startVPN after getting (or confirming) VPN.prepare permissions This resulted in the VPN not being turned on after logging in for the first time

Updates tailscale/tailscale#12148