### PR TITLE
android/ui: fix AndroidTV navigation issues

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/ui/util/ClipboardValueView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/util/ClipboardValueView.kt
@@ -20,13 +20,21 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
 import com.tailscale.ipn.R
 import com.tailscale.ipn.ui.theme.titledListItem
+import com.tailscale.ipn.ui.util.AndroidTVUtil.isAndroidTV
 
 @Composable
 fun ClipboardValueView(value: String, title: String? = null, subtitle: String? = null) {
   val localClipboardManager = LocalClipboardManager.current
+  val modifier =
+      if (isAndroidTV()) {
+        Modifier
+      } else {
+        Modifier.clickable { localClipboardManager.setText(AnnotatedString(value)) }
+      }
+
   ListItem(
       colors = MaterialTheme.colorScheme.titledListItem,
-      modifier = Modifier.clickable { localClipboardManager.setText(AnnotatedString(value)) },
+      modifier = modifier,
       overlineContent = title?.let { { Text(it, style = MaterialTheme.typography.titleMedium) } },
       headlineContent = { Text(text = value, style = MaterialTheme.typography.bodyMedium) },
       supportingContent =

--- a/android/src/main/java/com/tailscale/ipn/ui/util/Lists.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/util/Lists.kt
@@ -4,6 +4,7 @@
 package com.tailscale.ipn.ui.util
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -41,7 +42,8 @@ object Lists {
       title: String,
       bottomPadding: Dp = 0.dp,
       style: TextStyle = MaterialTheme.typography.titleMedium,
-      fontWeight: FontWeight? = null
+      fontWeight: FontWeight? = null,
+      focusable: Boolean = false
   ) {
     Box(
         modifier =
@@ -50,7 +52,8 @@ object Lists {
           Text(
               title,
               modifier =
-                  Modifier.padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = bottomPadding),
+                  Modifier.padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = bottomPadding)
+                      .focusable(focusable),
               style = style,
               fontWeight = fontWeight)
         }

--- a/android/src/main/java/com/tailscale/ipn/ui/view/PeerDetails.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/PeerDetails.kt
@@ -5,6 +5,7 @@ package com.tailscale.ipn.ui.view
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -33,6 +34,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.tailscale.ipn.R
 import com.tailscale.ipn.ui.theme.listItem
 import com.tailscale.ipn.ui.theme.short
+import com.tailscale.ipn.ui.util.AndroidTVUtil.isAndroidTV
 import com.tailscale.ipn.ui.util.Lists
 import com.tailscale.ipn.ui.util.itemsWithDividers
 import com.tailscale.ipn.ui.viewModel.PeerDetailsViewModel
@@ -101,14 +103,24 @@ fun PeerDetails(
 fun AddressRow(address: String, type: String) {
   val localClipboardManager = LocalClipboardManager.current
 
+  // Android TV doesn't have a clipboard, nor any way to use the values, so visible only.
+  val modifier =
+      if (isAndroidTV()) {
+        Modifier.focusable(false)
+      } else {
+        Modifier.clickable { localClipboardManager.setText(AnnotatedString(address)) }
+      }
+
   ListItem(
-      modifier = Modifier.clickable { localClipboardManager.setText(AnnotatedString(address)) },
+      modifier = modifier,
       colors = MaterialTheme.colorScheme.listItem,
       headlineContent = { Text(text = address) },
       supportingContent = { Text(text = type) },
       trailingContent = {
         // TODO: there is some overlap with other uses of clipboard, DRY
-        Icon(painter = painterResource(id = R.drawable.clipboard), null)
+        if (!isAndroidTV()) {
+          Icon(painter = painterResource(id = R.drawable.clipboard), null)
+        }
       })
 }
 

--- a/android/src/main/java/com/tailscale/ipn/ui/view/SettingsView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/SettingsView.kt
@@ -32,6 +32,7 @@ import com.tailscale.ipn.mdm.ShowHide
 import com.tailscale.ipn.ui.Links
 import com.tailscale.ipn.ui.theme.link
 import com.tailscale.ipn.ui.theme.listItem
+import com.tailscale.ipn.ui.util.AndroidTVUtil.isAndroidTV
 import com.tailscale.ipn.ui.util.Lists
 import com.tailscale.ipn.ui.util.set
 import com.tailscale.ipn.ui.viewModel.SettingsNav
@@ -61,7 +62,7 @@ fun SettingsView(settingsNav: SettingsNav, viewModel: SettingsViewModel = viewMo
                 onClick = settingsNav.onNavigateToUserSwitcher)
           }
 
-          if (isAdmin) {
+          if (isAdmin && !isAndroidTV()) {
             Lists.ItemDivider()
             AdminTextView { handler.openUri(Links.ADMIN_URL) }
           }

--- a/android/src/main/java/com/tailscale/ipn/ui/view/SharedViews.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/SharedViews.kt
@@ -22,12 +22,16 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.tailscale.ipn.ui.theme.topAppBar
 import com.tailscale.ipn.ui.theme.ts_color_light_blue
+import com.tailscale.ipn.ui.util.AndroidTVUtil.isAndroidTV
 
 typealias BackNavigation = () -> Unit
 
@@ -41,6 +45,12 @@ fun Header(
     actions: @Composable RowScope.() -> Unit = {},
     onBack: (() -> Unit)? = null
 ) {
+  val f = FocusRequester()
+
+  if (isAndroidTV()) {
+    LaunchedEffect(Unit) { f.requestFocus() }
+  }
+
   TopAppBar(
       title = {
         title?.let { title() }
@@ -51,21 +61,23 @@ fun Header(
       },
       colors = MaterialTheme.colorScheme.topAppBar,
       actions = actions,
-      navigationIcon = { onBack?.let { BackArrow(action = it) } },
+      navigationIcon = { onBack?.let { BackArrow(action = it, focusRequester = f) } },
   )
 }
 
 @Composable
-fun BackArrow(action: () -> Unit) {
+fun BackArrow(action: () -> Unit, focusRequester: FocusRequester) {
+
   Box(modifier = Modifier.padding(start = 8.dp, end = 8.dp)) {
     Icon(
         Icons.AutoMirrored.Filled.ArrowBack,
         contentDescription = "Go back to the previous screen",
         modifier =
-            Modifier.clickable(
-                interactionSource = remember { MutableInteractionSource() },
-                indication = rememberRipple(bounded = false),
-                onClick = { action() }))
+            Modifier.focusRequester(focusRequester)
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = rememberRipple(bounded = false),
+                    onClick = { action() }))
   }
 }
 


### PR DESCRIPTION
updates tailscale/corp#20930

This addresses several issues with AndroidTV navigation,
all possible causes of the 1.68 rejection (the exact reasons
are unknown - we're await clarification).  But in the mean time:

The search bar is removed until we have a better solution
for D-pad navigation.   This should be addressed when we
switch to a less customized component.   Full replacement of
the search functionality is beyond the scope of this change.

The back button will now automatically request the focus on AndroidTV 
devices by default so there is always at least one element focussed.

Views with clipboard support are disabled since this was 
not functional (nothing was getting copied to the clipboard).

View with embedded links are removed since these
require touch support and a browser.