### PR TITLE
android/ui: open login screen on toggle

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/MainViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/MainViewModel.kt
@@ -13,6 +13,7 @@ import com.tailscale.ipn.mdm.MDMSettings
 import com.tailscale.ipn.ui.model.Ipn
 import com.tailscale.ipn.ui.model.Ipn.State
 import com.tailscale.ipn.ui.notifier.Notifier
+import com.tailscale.ipn.ui.util.AndroidTVUtil.isAndroidTV
 import com.tailscale.ipn.ui.util.PeerCategorizer
 import com.tailscale.ipn.ui.util.PeerSet
 import com.tailscale.ipn.ui.util.TimeUtil
@@ -112,6 +113,7 @@ class MainViewModel : IpnViewModel() {
     when {
       !isPrepared -> showVPNPermissionLauncherIfUnauthorized()
       state == Ipn.State.Running -> stopVPN()
+      state == Ipn.State.NeedsLogin && isAndroidTV() -> login()
       else -> startVPN()
     }
   }


### PR DESCRIPTION
updates tailscale/corp#20930

To address review concerns regarding the toggle being unresponsive with the d-pad.  We'll now open the QR login screen on android TV if you toggle the VPN when we're in the NeedsLogin state.