### PR TITLE
android/ui: remove switch and status label on TV before login

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/ui/view/MainView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/MainView.kt
@@ -129,17 +129,22 @@ fun MainView(
             val disableToggle by MDMSettings.forceEnabled.flow.collectAsState(initial = true)
             val showKeyExpiry by viewModel.showExpiry.collectAsState(initial = false)
 
+            // Hide the header only on Android TV when the user needs to login
+            val hideHeader = (isAndroidTV() && state == Ipn.State.NeedsLogin)
+
             ListItem(
                 colors = MaterialTheme.colorScheme.surfaceContainerListItem,
                 leadingContent = {
-                  TintedSwitch(
-                      onCheckedChange = {
-                        if (!disableToggle) {
-                          viewModel.toggleVpn()
-                        }
-                      },
-                      enabled = !disableToggle,
-                      checked = isOn)
+                  if (!hideHeader) {
+                    TintedSwitch(
+                        onCheckedChange = {
+                          if (!disableToggle) {
+                            viewModel.toggleVpn()
+                          }
+                        },
+                        enabled = !disableToggle,
+                        checked = isOn)
+                  }
                 },
                 headlineContent = {
                   user?.NetworkProfile?.DomainName?.let { domain ->
@@ -151,7 +156,9 @@ fun MainView(
                   }
                 },
                 supportingContent = {
-                  Text(text = stateStr, style = MaterialTheme.typography.bodyMedium.short)
+                  if (!hideHeader) {
+                    Text(text = stateStr, style = MaterialTheme.typography.bodyMedium.short)
+                  }
                 },
                 trailingContent = {
                   Box(modifier = Modifier.weight(1f), contentAlignment = Alignment.CenterEnd) {


### PR DESCRIPTION
updates tailscale/corp#20930

Google reviewers were unhappy that there was a non-actionable label for AndroidTV when before login had happened, so that has been removed.

![Screenshot 2024-06-20 at 12 45 10 PM](https://github.com/tailscale/tailscale-android/assets/779591/6b59baa2-9e03-452b-8263-128248308c56)
