### PR TITLE
health: only display system notifications for high severity warnings,…

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/App.kt
+++ b/android/src/main/java/com/tailscale/ipn/App.kt
@@ -72,7 +72,7 @@ class App : UninitializedApp(), libtailscale.AppContext {
   val dns = DnsConfig()
   private lateinit var connectivityManager: ConnectivityManager
   private lateinit var app: libtailscale.Application
-  private var healthNotifier: HealthNotifier? = null
+  var healthNotifier: HealthNotifier? = null
 
   override fun getPlatformDNSConfig(): String = dns.dnsConfigAsString
 

--- a/android/src/main/java/com/tailscale/ipn/ui/model/Health.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/model/Health.kt
@@ -3,6 +3,11 @@
 
 package com.tailscale.ipn.ui.model
 
+import androidx.compose.material3.ListItemColors
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import com.tailscale.ipn.ui.theme.warning
 import kotlinx.serialization.Serializable
 
 class Health {
@@ -21,18 +26,59 @@ class Health {
       var BrokenSince: String? = null,
       var Args: Map<String, String>? = null,
       var DependsOn: List<String>? = null, // an array of WarnableCodes this depends on
-  ) {
+  ) : Comparable<UnhealthyState> {
     fun hiddenByDependencies(currentWarnableCodes: Set<String>): Boolean {
       return this.DependsOn?.let {
         it.any { depWarnableCode -> currentWarnableCodes.contains(depWarnableCode) }
       } == true
     }
+
+    override fun compareTo(other: UnhealthyState): Int {
+      // Compare by severity first
+      val severityComparison = Severity.compareTo(other.Severity)
+      if (severityComparison != 0) {
+        return severityComparison
+      }
+
+      // If severities are equal, compare by warnableCode
+      return WarnableCode.compareTo(other.WarnableCode)
+    }
   }
 
   @Serializable
-  enum class Severity {
-    high,
+  enum class Severity : Comparable<Severity> {
+    low,
     medium,
-    low
+    high;
+
+    @Composable
+    fun listItemColors(): ListItemColors {
+      val default = ListItemDefaults.colors()
+      return when (this) {
+        Severity.low ->
+            ListItemColors(
+                containerColor = MaterialTheme.colorScheme.surface,
+                headlineColor = MaterialTheme.colorScheme.secondary,
+                leadingIconColor = MaterialTheme.colorScheme.secondary,
+                overlineColor = MaterialTheme.colorScheme.secondary.copy(alpha = 0.8f),
+                supportingTextColor = MaterialTheme.colorScheme.secondary,
+                trailingIconColor = MaterialTheme.colorScheme.secondary,
+                disabledHeadlineColor = default.disabledHeadlineColor,
+                disabledLeadingIconColor = default.disabledLeadingIconColor,
+                disabledTrailingIconColor = default.disabledTrailingIconColor)
+        Severity.medium,
+        Severity.high ->
+            ListItemColors(
+                containerColor = MaterialTheme.colorScheme.warning,
+                headlineColor = MaterialTheme.colorScheme.onPrimary,
+                leadingIconColor = MaterialTheme.colorScheme.onPrimary,
+                overlineColor = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.8f),
+                supportingTextColor = MaterialTheme.colorScheme.onPrimary,
+                trailingIconColor = MaterialTheme.colorScheme.onPrimary,
+                disabledHeadlineColor = default.disabledHeadlineColor,
+                disabledLeadingIconColor = default.disabledLeadingIconColor,
+                disabledTrailingIconColor = default.disabledTrailingIconColor)
+      }
+    }
   }
 }

--- a/android/src/main/java/com/tailscale/ipn/ui/view/MainView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/MainView.kt
@@ -73,6 +73,7 @@ import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.tailscale.ipn.R
 import com.tailscale.ipn.mdm.MDMSettings
 import com.tailscale.ipn.mdm.ShowHide
+import com.tailscale.ipn.ui.model.Health
 import com.tailscale.ipn.ui.model.Ipn
 import com.tailscale.ipn.ui.model.IpnLocal
 import com.tailscale.ipn.ui.model.Netmap
@@ -117,6 +118,7 @@ fun MainView(
     viewModel: MainViewModel
 ) {
   val currentPingDevice by viewModel.pingViewModel.peer.collectAsState()
+  val healthWarnings by viewModel.healthWarnings.collectAsState()
 
   LoadingIndicator.Wrap {
     Scaffold(contentWindowInsets = WindowInsets.Companion.statusBars) { paddingInsets ->
@@ -198,6 +200,10 @@ fun MainView(
                   ExpiryNotification(netmap = netmap, action = { viewModel.login() })
                 }
 
+                for (warning in healthWarnings) {
+                  HealthNotification(warning = warning)
+                }
+
                 if (showExitNodePicker == ShowHide.Show) {
                   ExitNodeStatus(
                       navAction = navigation.onNavigateToExitNodes, viewModel = viewModel)
@@ -225,7 +231,9 @@ fun MainView(
           }
 
       currentPingDevice?.let { peer ->
-        ModalBottomSheet(onDismissRequest = { viewModel.onPingDismissal() }) { PingView(model = viewModel.pingViewModel) }
+        ModalBottomSheet(onDismissRequest = { viewModel.onPingDismissal() }) {
+          PingView(model = viewModel.pingViewModel)
+        }
       }
     }
   }
@@ -696,6 +704,29 @@ fun ExpiryNotification(netmap: Netmap.NetworkMap?, action: () -> Unit = {}) {
                 Text(
                     stringResource(id = R.string.keyExpiryExplainer),
                     style = MaterialTheme.typography.bodyMedium)
+              })
+        }
+  }
+}
+
+@Composable
+fun HealthNotification(warning: Health.UnhealthyState) {
+  Box(modifier = Modifier.background(color = MaterialTheme.colorScheme.surfaceContainerLow)) {
+    Box(
+        modifier =
+            Modifier.padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 8.dp)
+                .clip(shape = RoundedCornerShape(10.dp, 10.dp, 10.dp, 10.dp))
+                .fillMaxWidth()) {
+          ListItem(
+              colors = warning.Severity.listItemColors(),
+              headlineContent = {
+                Text(
+                    warning.Title,
+                    style = MaterialTheme.typography.titleMedium,
+                )
+              },
+              supportingContent = {
+                Text(warning.Text, style = MaterialTheme.typography.bodyMedium)
               })
         }
   }

--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/MainViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/MainViewModel.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.viewModelScope
 import com.tailscale.ipn.App
 import com.tailscale.ipn.R
 import com.tailscale.ipn.mdm.MDMSettings
+import com.tailscale.ipn.ui.model.Health
 import com.tailscale.ipn.ui.model.Ipn
 import com.tailscale.ipn.ui.model.Ipn.State
 import com.tailscale.ipn.ui.model.Tailcfg
@@ -55,6 +56,9 @@ class MainViewModel : IpnViewModel() {
   var expandedMenuPeer: StateFlow<Tailcfg.Node?> = MutableStateFlow(null)
 
   var pingViewModel: PingViewModel = PingViewModel()
+
+  // Health warnings displayed in the UI, if any
+  val healthWarnings: StateFlow<List<Health.UnhealthyState>> = MutableStateFlow(listOf())
 
   fun hidePeerDropdownMenu() {
     expandedMenuPeer.set(null)
@@ -117,6 +121,12 @@ class MainViewModel : IpnViewModel() {
 
     viewModelScope.launch {
       searchTerm.collect { term -> peers.set(peerCategorizer.groupedAndFilteredPeers(term)) }
+    }
+
+    viewModelScope.launch {
+      App.get().healthNotifier?.currentWarnings?.collect { warnings ->
+        healthWarnings.set(warnings.sorted())
+      }
     }
   }
 


### PR DESCRIPTION
Updates tailscale/tailscale#4136

<img src="https://github.com/tailscale/tailscale-android/assets/9057073/ad331009-4b8f-4ee7-8238-9b64a75ac556" align="right" width="300">

This PR brings the Android health system in line with recent macOS/iOS changes. Only high severity notifications will now trigger a system notification; meanwhile all notifications are now displayed in the app home screen, like we do on iOS. The "warming-up" Warnable is observed to prevent spurious notifications from appearing while the app has just launched.

Screenshot is only meant to be indicative of what a low-severity notification looks like, we don't actually show notifications when running an unstable build on Android.