### PR TITLE
docs/makefile: update docker build instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ tailscale-debug: $(DEBUG_APK) ## Build the debug APK
 
 .PHONY: release
 release: jarsign-env $(RELEASE_AAB) ## Build the release AAB
-	jarsigner -sigalg SHA256withRSA -digestalg SHA-256 -keystore $(JKS_PATH) -storepass $(JKS_PASSWORD) $(RELEASE_AAB) tailscale
+	@jarsigner -sigalg SHA256withRSA -digestalg SHA-256 -keystore $(JKS_PATH) -storepass $(JKS_PASSWORD) $(RELEASE_AAB) tailscale
 
 # gradle-dependencies groups together the android sources and libtailscale needed to assemble tests/debug/release builds.
 .PHONY: gradle-dependencies

--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ If you wish to avoid installing software on your host system, a Docker based dev
 make dockershell
 ```
 
+Several other makefile recipes are available for setting up the proper build environment and running builds.
+
+Note that the docker makefile recipes s will preserve the image and remove container on completion. 
+If changes are made to the build environment or toolchain, cached docker images may need to be rebuilt.  
+The docker build image name is parameterized in the makefile and changing it provides a simple means to do this.
+
 ### Nix
 
 If you have Nix 2.4 or later installed, a Nix development environment can


### PR DESCRIPTION
#cleanup

Updated the notes on refreshing docker build containers 
Removed the jarsign output so we're not logging the jks password