### PR TITLE
ui: only show high severity warnings in-app for 1.70

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/MainViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/MainViewModel.kt
@@ -125,7 +125,9 @@ class MainViewModel : IpnViewModel() {
 
     viewModelScope.launch {
       App.get().healthNotifier?.currentWarnings?.collect { warnings ->
-        healthWarnings.set(warnings.sorted())
+        healthWarnings.set(warnings
+          .filter { it.Severity == Health.Severity.high }
+          .sorted())
       }
     }
   }


### PR DESCRIPTION
As discussed with @barnstar, let's hide health messages within the app's main screen unless they are high severity. Low and mid-severity messages will be re-added in a more subtle, later iteration with a dedicated health messages view.