### PR TITLE
android/gradle: separate release and release_tv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,10 +108,12 @@ $(DEBUG_APK): gradle-dependencies
 	install -C android/build/outputs/apk/debug/android-debug.apk $@
 
 $(RELEASE_AAB): gradle-dependencies
+	@echo "Building release AAB"
 	(cd android && ./gradlew test bundleRelease)
 	install -C ./android/build/outputs/bundle/release/android-release.aab $@
 
 $(RELEASE_TV_AAB): gradle-dependencies
+	@echo "Building TV release AAB"
 	(cd android && ./gradlew test bundleRelease_tv)
 	install -C ./android/build/outputs/bundle/release_tv/android-release_tv.aab $@
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -75,6 +75,7 @@ android {
         }
         release {
             manifestPlaceholders.leanbackRequired = false
+
             minifyEnabled true
 
             shrinkResources true
@@ -84,15 +85,8 @@ android {
                     'proguard-rules.pro'
         }
         release_tv {
+            initWith release
             manifestPlaceholders.leanbackRequired = true
-
-            minifyEnabled true
-
-            shrinkResources true
-
-            proguardFiles getDefaultProguardFile(
-                    'proguard-android-optimize.txt'),
-                    'proguard-rules.pro'
         }
     }
 


### PR DESCRIPTION
 updates tailscale/corp#21644

release_tv should init with the release target or it doesn't build the right thing.