### PR TITLE
android/docker: combine CMD invocations into a single line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 # The docker image to use for the build environment.  Changing this
 # will force a rebuild of the docker image.  If there is an existing image
 # with this name, it will be used.
-DOCKER_IMAGE=tailscale-android-build-amd64-2
+DOCKER_IMAGE=tailscale-android-build-amd64
 
 DEBUG_APK=tailscale-debug.apk
 RELEASE_AAB=tailscale-release.aab

--- a/docker/DockerFile.amd64-build
+++ b/docker/DockerFile.amd64-build
@@ -41,11 +41,6 @@ COPY android/gradlew android/gradlew
 COPY android/gradle android/gradle
 RUN ./android/gradlew
 
-# Build the android app
-CMD make clean
-CMD make release
-# Build the android tv app.  We need to bump the version code by 1
-# so the AAB is unique.
-CMD make bump_version_code
-CMD make release-tv
+# Build the android app, bump the playstore version code, and make the tv release
+CMD make release && make bump_version_code && make release-tv
 


### PR DESCRIPTION
 updates tailscale/corp#21644

Docker ignores all but the last CMD invocation (silently).  These have to be combined into a single line. 

The clean is redundant.  We run a clean on the mounted directory before we kick off make docker-run-build.

The image name  is updated to ensure it's rebuilt.