### PR TITLE
android: bump OSS to 1.71.x; update dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.5.0'
+        classpath 'com.android.tools.build:gradle:8.5.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
         classpath("com.ncorti.ktfmt.gradle:plugin:0.17.0")
@@ -116,7 +116,7 @@ dependencies {
     implementation 'androidx.compose.material:material-icons-core:1.6.8'
     implementation "androidx.compose.ui:ui:1.6.8"
     implementation "androidx.compose.ui:ui-tooling:1.6.8"
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.2'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.3'
     implementation 'androidx.activity:activity-compose:1.9.0'
     implementation "com.google.accompanist:accompanist-permissions:$accompanist_version"
     implementation "com.google.accompanist:accompanist-systemuicontroller:$accompanist_version"
@@ -138,10 +138,10 @@ dependencies {
 
     // Integration Tests
     androidTestImplementation composeBom
-    androidTestImplementation 'androidx.test:runner:1.6.0'
-    androidTestImplementation 'androidx.test.ext:junit-ktx:1.2.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.2.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.0'
+    androidTestImplementation 'androidx.test:runner:1.6.1'
+    androidTestImplementation 'androidx.test.ext:junit-ktx:1.2.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
     implementation 'androidx.test.uiautomator:uiautomator:2.3.0'
 
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,5 @@
 android.defaults.buildfeatures.buildconfig=true
 android.nonFinalResIds=false
-android.nonTransitiveRClass=false
+android.nonTransitiveRClass=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/mobile v0.0.0-20240319015410-c58ccf4b0c87
 	golang.org/x/sys v0.21.0
 	inet.af/netaddr v0.0.0-20220617031823-097006376321
-	tailscale.com v1.69.0-pre.0.20240715093413-fec41e490419
+	tailscale.com v1.71.0-pre.0.20240724075806-ba7f2d129eb1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -258,5 +258,5 @@ nhooyr.io/websocket v1.8.10 h1:mv4p+MnGrLDcPlBoWsvPP7XCzTYMXP9F9eIGoKbgx7Q=
 nhooyr.io/websocket v1.8.10/go.mod h1:rN9OFWIUwuxg4fR5tELlYC04bXYowCP9GX47ivo2l+c=
 software.sslmate.com/src/go-pkcs12 v0.4.0 h1:H2g08FrTvSFKUj+D309j1DPfk5APnIdAQAB8aEykJ5k=
 software.sslmate.com/src/go-pkcs12 v0.4.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=
-tailscale.com v1.69.0-pre.0.20240715093413-fec41e490419 h1:FrHdrwpd7pfQNCEzwvxdFMDA4THdHwJGX4qmjuOGWdc=
-tailscale.com v1.69.0-pre.0.20240715093413-fec41e490419/go.mod h1:a5yWox+uO5CI4tCB9ot0ZPMdQMiC+Pis9mudVaYETIo=
+tailscale.com v1.71.0-pre.0.20240724075806-ba7f2d129eb1 h1:HJQEZliPn4Fe9smZ6oRQkwa8aow7htws8UegV5aNiY4=
+tailscale.com v1.71.0-pre.0.20240724075806-ba7f2d129eb1/go.mod h1:jPISnYOCTAUga3Qqbb3V/53xpBm+4dTQl5T970LqybM=


### PR DESCRIPTION
Fixes #cleanup

Bumps OSS, updates dependencies and enables `android.nonTransitiveRClass` to improve build times.