### PR TITLE
android: prepare VPN when quick tile is clicked

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/ui/view/MainView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/MainView.kt
@@ -70,6 +70,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.tailscale.ipn.App
 import com.tailscale.ipn.R
 import com.tailscale.ipn.mdm.MDMSettings
 import com.tailscale.ipn.mdm.ShowHide
@@ -101,6 +102,7 @@ import com.tailscale.ipn.ui.util.itemsWithDividers
 import com.tailscale.ipn.ui.util.set
 import com.tailscale.ipn.ui.viewModel.IpnViewModel.NodeState
 import com.tailscale.ipn.ui.viewModel.MainViewModel
+import com.tailscale.ipn.ui.viewModel.VpnViewModel
 
 // Navigation actions for the MainView
 data class MainViewNavigation(
@@ -128,7 +130,7 @@ fun MainView(
             // Assume VPN has been prepared for optimistic UI. Whether or not it has been prepared
             // cannot be known
             // until permission has been granted to prepare the VPN.
-            val isPrepared by viewModel.vpnPrepared.collectAsState(initial = true)
+            val isPrepared by viewModel.isVpnPrepared.collectAsState(initial = true)
             val isOn by viewModel.vpnToggleState.collectAsState(initial = false)
             val state by viewModel.ipnState.collectAsState(initial = Ipn.State.NoState)
             val user by viewModel.loggedInUser.collectAsState(initial = null)
@@ -283,7 +285,7 @@ fun ExitNodeStatus(navAction: () -> Unit, viewModel: MainViewModel) {
                         Modifier.padding(start = 16.dp, end = 16.dp, top = 36.dp, bottom = 16.dp)) {
                       Text(
                           text =
-                              managedByOrganization.value?.let {
+                              managedByOrganization?.let {
                                 stringResource(R.string.exit_node_offline_mdm_orgname, it)
                               } ?: stringResource(R.string.exit_node_offline_mdm),
                           style = MaterialTheme.typography.bodyMedium,
@@ -735,7 +737,9 @@ fun PromptPermissionsIfNecessary() {
 @Preview
 @Composable
 fun MainViewPreview() {
-  val vm = MainViewModel()
+  val vpnViewModel = VpnViewModel(App.get())
+  val vm = MainViewModel(vpnViewModel)
+
   MainView(
       {},
       MainViewNavigation(

--- a/android/src/main/java/com/tailscale/ipn/ui/view/SettingsView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/SettingsView.kt
@@ -37,9 +37,11 @@ import com.tailscale.ipn.ui.util.Lists
 import com.tailscale.ipn.ui.util.set
 import com.tailscale.ipn.ui.viewModel.SettingsNav
 import com.tailscale.ipn.ui.viewModel.SettingsViewModel
+import com.tailscale.ipn.ui.viewModel.VpnViewModel
+import com.tailscale.ipn.ui.notifier.Notifier
 
 @Composable
-fun SettingsView(settingsNav: SettingsNav, viewModel: SettingsViewModel = viewModel()) {
+fun SettingsView(settingsNav: SettingsNav, viewModel: SettingsViewModel = viewModel(), vpnViewModel: VpnViewModel = viewModel()) {
   val handler = LocalUriHandler.current
 
   val user by viewModel.loggedInUser.collectAsState()
@@ -47,7 +49,7 @@ fun SettingsView(settingsNav: SettingsNav, viewModel: SettingsViewModel = viewMo
   val managedByOrganization by viewModel.managedByOrganization.collectAsState()
   val tailnetLockEnabled by viewModel.tailNetLockEnabled.collectAsState()
   val corpDNSEnabled by viewModel.corpDNSEnabled.collectAsState()
-  val isVPNPrepared by viewModel.vpnPrepared.collectAsState()
+  val isVPNPrepared by vpnViewModel.vpnPrepared.collectAsState()
   val showTailnetLock by MDMSettings.manageTailnetLock.flow.collectAsState()
 
   Scaffold(

--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/IpnViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/IpnViewModel.kt
@@ -3,11 +3,9 @@
 
 package com.tailscale.ipn.ui.viewModel
 
-import android.net.VpnService
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.tailscale.ipn.App
 import com.tailscale.ipn.UninitializedApp
 import com.tailscale.ipn.mdm.MDMSettings
 import com.tailscale.ipn.ui.localapi.Client
@@ -64,16 +62,6 @@ open class IpnViewModel : ViewModel() {
   }
 
   init {
-    // Check if the user has granted permission yet.
-    if (!vpnPrepared.value) {
-      val vpnIntent = VpnService.prepare(App.get())
-      if (vpnIntent != null) {
-        setVpnPrepared(false)
-      } else {
-        setVpnPrepared(true)
-      }
-    }
-
     viewModelScope.launch {
       Notifier.state.collect {
         // Reload the user profiles on all state transitions to ensure loggedInUser is correct

--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/SettingsViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/SettingsViewModel.kt
@@ -47,11 +47,7 @@ class SettingsViewModel : IpnViewModel() {
 
     viewModelScope.launch {
       Notifier.prefs.collect {
-        it?.let {
-          corpDNSEnabled.set(it.CorpDNS)
-        } ?: run {
-          corpDNSEnabled.set(null)
-        }
+        it?.let { corpDNSEnabled.set(it.CorpDNS) } ?: run { corpDNSEnabled.set(null) }
       }
     }
   }

--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/VpnViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/VpnViewModel.kt
@@ -1,0 +1,48 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package com.tailscale.ipn.ui.viewModel
+
+import android.app.Application
+import android.net.VpnService
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class VpnViewModelFactory(private val application: Application) : ViewModelProvider.Factory {
+  @Suppress("UNCHECKED_CAST")
+  override fun <T : ViewModel> create(modelClass: Class<T>): T {
+    if (modelClass.isAssignableFrom(VpnViewModel::class.java)) {
+      return VpnViewModel(application) as T
+    }
+    throw IllegalArgumentException("Unknown ViewModel class")
+  }
+}
+
+class VpnViewModel(application: Application) : AndroidViewModel(application) {
+  // Whether the VPN is prepared
+  val _vpnPrepared = MutableStateFlow(false)
+  val vpnPrepared: StateFlow<Boolean> = _vpnPrepared
+
+  init {
+    prepareVpn()
+  }
+
+  private fun prepareVpn() {
+    // Check if the user has granted permission yet.
+    if (!vpnPrepared.value) {
+      val vpnIntent = VpnService.prepare(getApplication())
+      if (vpnIntent != null) {
+        setVpnPrepared(false)
+      } else {
+        setVpnPrepared(true)
+      }
+    }
+  }
+
+  fun setVpnPrepared(prepared: Boolean) {
+    _vpnPrepared.value = prepared
+  }
+}


### PR DESCRIPTION
Currently, the VPN is prepared when MainActivity is launched. If Tailscale is enabled by a quick tile, the VPN is not prepared.

Fixes tailscale/tailscale#12489