### PR TITLE
android: bump oss and version code

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,8 +37,8 @@ android {
     defaultConfig {
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 240
-        versionName "1.69.157-tfec41e490-gca91191cc6a"
+        versionCode 241
+        versionName "1.71.20-tba7f2d129-g1465b2a67f4-dirty"
     }
 
     compileOptions {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/mobile v0.0.0-20240319015410-c58ccf4b0c87
 	golang.org/x/sys v0.21.0
 	inet.af/netaddr v0.0.0-20220617031823-097006376321
-	tailscale.com v1.71.0-pre.0.20240724075806-ba7f2d129eb1
+	tailscale.com v1.71.0-pre.0.20240725132017-855da477773c
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -258,5 +258,5 @@ nhooyr.io/websocket v1.8.10 h1:mv4p+MnGrLDcPlBoWsvPP7XCzTYMXP9F9eIGoKbgx7Q=
 nhooyr.io/websocket v1.8.10/go.mod h1:rN9OFWIUwuxg4fR5tELlYC04bXYowCP9GX47ivo2l+c=
 software.sslmate.com/src/go-pkcs12 v0.4.0 h1:H2g08FrTvSFKUj+D309j1DPfk5APnIdAQAB8aEykJ5k=
 software.sslmate.com/src/go-pkcs12 v0.4.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=
-tailscale.com v1.71.0-pre.0.20240724075806-ba7f2d129eb1 h1:HJQEZliPn4Fe9smZ6oRQkwa8aow7htws8UegV5aNiY4=
-tailscale.com v1.71.0-pre.0.20240724075806-ba7f2d129eb1/go.mod h1:jPISnYOCTAUga3Qqbb3V/53xpBm+4dTQl5T970LqybM=
+tailscale.com v1.71.0-pre.0.20240725132017-855da477773c h1:UbOaZH1klFugFog55qc2w6tGVY3BckZqN1FFTlZ30+8=
+tailscale.com v1.71.0-pre.0.20240725132017-855da477773c/go.mod h1:jPISnYOCTAUga3Qqbb3V/53xpBm+4dTQl5T970LqybM=


### PR DESCRIPTION
Last bump didn't update the version in the gradle file (unstable is still at 1.69).  This bumps again and sets the version to 1.71.