### PR TITLE
libtailscale, android: translate NoSuchKeyException as syspolicy.ErrNoSuchKey

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/mdm/MDMSettings.kt
+++ b/android/src/main/java/com/tailscale/ipn/mdm/MDMSettings.kt
@@ -12,8 +12,10 @@ import kotlin.reflect.jvm.jvmErasure
 
 object MDMSettings {
   // The String message used in this NoSuchKeyException must match the value of
-  // syspolicy.ErrNoSuchKey defined in Go, since the backend checks the value
-  // returned by the handler for equality using errors.Is().
+  // syspolicy.ErrNoSuchKey defined in Go. We compare against its exact text
+  // to determine whether the requested policy setting is not configured and
+  // an actual syspolicy.ErrNoSuchKey should be returned from syspolicyHandler
+  // to the backend.
   class NoSuchKeyException : Exception("no such key")
 
   val forceEnabled = BooleanMDMSetting("ForceEnabled", "Force Enabled Connection Toggle")


### PR DESCRIPTION
Currently, `NoSuchKeyException` gets translated by gomobile to a Go error with "no such key" as the text. It is imperative for `syspolicy.Handler` implementations to return `syspolicy.ErrNoSuchKey` if a policy setting is not configured, so this PR adds translation for errors that do not already wrap `syspolicy.ErrNoSuchKey`, but have "no such key" as the text.

Updates tailscale/tailscale#12687