### PR TITLE
mdm: return values rather than the constant names for the setting enums

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/mdm/MDMSettingsDefinitions.kt
+++ b/android/src/main/java/com/tailscale/ipn/mdm/MDMSettingsDefinitions.kt
@@ -85,9 +85,17 @@ enum class AlwaysNeverUserDecides(val value: String) {
     get() {
       return this != UserDecides
     }
+
+  override fun toString(): String {
+    return value
+  }
 }
 
 enum class ShowHide(val value: String) {
   Show("show"),
-  Hide("hide")
+  Hide("hide");
+
+  override fun toString(): String {
+    return value
+  }
 }


### PR DESCRIPTION
We stringify setting values with `toString` before returning them from the `syspolicyHandler`. For enum setting types, such as `AlwaysNeverUserDecides` and `ShowHide`, the default `toString` implementation returns the enum constant names, such as `Always` and `UserDecides`. However, the Go backend requires us to return `always`, `never`, and `user-decides` values, exactly, and falls back to the default value (e.g., `user-decides`) if it receives anything else from the app.

This PR overrides the `toString` methods on both enums to return the required values rather than the constant names.

Updates tailscale/tailscale#12687