### PR TITLE
libtailscale, mdm: allow syspolicy to subscribe to policy change notifications

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/App.kt
+++ b/android/src/main/java/com/tailscale/ipn/App.kt
@@ -338,6 +338,10 @@ class App : UninitializedApp(), libtailscale.AppContext {
       throw MDMSettings.NoSuchKeyException()
     }
   }
+
+  fun notifyPolicyChanged() {
+    app.notifyPolicyChanged()
+  }
 }
 
 /**

--- a/android/src/main/java/com/tailscale/ipn/mdm/MDMSettings.kt
+++ b/android/src/main/java/com/tailscale/ipn/mdm/MDMSettings.kt
@@ -107,5 +107,6 @@ object MDMSettings {
     val bundle = restrictionsManager?.applicationRestrictions
     val preferences = lazy { app.getEncryptedPrefs() }
     allSettings.forEach { it.setFrom(bundle, preferences) }
+    app.notifyPolicyChanged()
   }
 }

--- a/libtailscale/backend.go
+++ b/libtailscale/backend.go
@@ -45,6 +45,7 @@ type App struct {
 	appCtx AppContext
 
 	store             *stateStore
+	policyStore       *syspolicyHandler
 	logIDPublicAtomic atomic.Pointer[logid.PublicID]
 
 	localAPIHandler http.Handler

--- a/libtailscale/interfaces.go
+++ b/libtailscale/interfaces.go
@@ -102,6 +102,10 @@ type Application interface {
 	// it accepts multiple FileParts that get encoded as multipart/form-data.
 	CallLocalAPIMultipart(timeoutMillis int, method, endpoint string, parts FileParts) (LocalAPIResponse, error)
 
+	// NotifyPolicyChanged notifies the backend about a changed MDM policy,
+	// so it can re-read it via the [syspolicyHandler].
+	NotifyPolicyChanged()
+
 	// WatchNotifications provides a mechanism for subscribing to ipn.Notify
 	// updates. The given NotificationCallback's OnNotify function is invoked
 	// on every new ipn.Notify message. The returned NotificationManager

--- a/libtailscale/localapi.go
+++ b/libtailscale/localapi.go
@@ -107,6 +107,10 @@ func (app *App) CallLocalAPIMultipart(timeoutMillis int, method, endpoint string
 	}
 }
 
+func (app *App) NotifyPolicyChanged() {
+	app.policyStore.notifyChanged()
+}
+
 func (app *App) EditPrefs(prefs ipn.MaskedPrefs) (LocalAPIResponse, error) {
 	r, w := io.Pipe()
 	go func() {

--- a/libtailscale/tailscale.go
+++ b/libtailscale/tailscale.go
@@ -39,8 +39,9 @@ func newApp(dataDir, directFileRoot string, appCtx AppContext) Application {
 	a.ready.Add(2)
 
 	a.store = newStateStore(a.appCtx)
+	a.policyStore = &syspolicyHandler{a: a}
 	netmon.RegisterInterfaceGetter(a.getInterfaces)
-	syspolicy.RegisterHandler(syspolicyHandler{a: a})
+	syspolicy.RegisterHandler(a.policyStore)
 	go func() {
 		defer func() {
 			if p := recover(); p != nil {


### PR DESCRIPTION
In preparation for upcoming syspolicy improvements, we'd like to allow subscriptions to policy change notifications via the `syspolicyHandler.RegisterChangeCallback`. The registered callbacks are invoked whenever `MDMSettings.update` is called.

Updates tailscale/tailscale#12687