### PR TITLE
android: check if other VPN is active

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/MainViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/MainViewModel.kt
@@ -100,8 +100,10 @@ class MainViewModel(private val vpnViewModel: VpnViewModel) : IpnViewModel() {
 
             val isOn =
                 when {
-                  currentState == State.Running || currentState == State.Starting -> true
-                  previousState == State.NoState && currentState == State.Starting -> true
+                  prepared && currentState == State.Running || currentState == State.Starting ->
+                      true
+                  previousState == State.NoState && currentState == State.Starting ->
+                      true
                   else -> false
                 }
 
@@ -182,7 +184,7 @@ private fun userStringRes(currentState: State?, previousState: State?, vpnPrepar
     currentState == State.NeedsMachineAuth -> R.string.needs_machine_auth
     currentState == State.Stopped -> R.string.stopped
     currentState == State.Starting -> R.string.starting
-    currentState == State.Running -> R.string.connected
+    currentState == State.Running -> if (vpnPrepared) R.string.connected else R.string.placeholder
     else -> R.string.placeholder
   }
 }

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -292,4 +292,11 @@
     <string name="health_warnings">Health warnings</string>
     <string name="no_issues_found">No issues found</string>
     <string name="tailscale_is_operating_normally">Tailscale is operating normally.</string>
+
+    <!-- Strings for the multiple VPNs dialog -->
+    <string name="vpn_permission_denied">VPN permission denied</string>
+    <string name="multiple_vpn_explainer">Only one VPN can be active, and it appears another is already running. Before starting Tailscale, disable the other VPN.</string>
+    <string name="go_to_settings">Go to Settings</string>
+    <string name="cancel">Cancel</string>
+
 </resources>


### PR DESCRIPTION
Detect when another VPN is active and launch dialog giving user the option to navigate to settings to disable. Update state string and toggle to require successful VPN preparation

To do in a follow-up: monitor VPN connection, and if Tailscale VPN disconnects due to another VPN connecting, update toggle and text

Updates tailscale/tailscale#12850