### PR TITLE
mdm: add AuthKey piping

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,7 +38,7 @@ android {
         minSdkVersion 26
         targetSdkVersion 34
         versionCode 241
-        versionName "1.73.0-t1e8f8ee5f-ga843c93669f"
+        versionName "1.73.13-taf3d3c433-g536e1adcc42"
     }
 
     compileOptions {

--- a/android/src/main/java/com/tailscale/ipn/mdm/MDMSettings.kt
+++ b/android/src/main/java/com/tailscale/ipn/mdm/MDMSettings.kt
@@ -91,6 +91,9 @@ object MDMSettings {
   // apps skip the VPN tunnel.
   val includedPackages = StringMDMSetting("IncludedPackageNames", "Included Package Names")
 
+  // Handled on the backend
+  val authKey = StringMDMSetting("AuthKey", "Auth Key for login")
+
   val allSettings by lazy {
     MDMSettings::class
         .declaredMemberProperties

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -298,5 +298,7 @@
     <string name="multiple_vpn_explainer">Only one VPN can be active, and it appears another is already running. Before starting Tailscale, disable the other VPN.</string>
     <string name="go_to_settings">Go to Settings</string>
     <string name="cancel">Cancel</string>
+    <string name="defines_an_auth_key_that_will_be_used_for_login">Defines an auth key that will be used for login.</string>
+    <string name="auth_key">Auth Key</string>
 
 </resources>

--- a/android/src/main/res/xml/app_restrictions.xml
+++ b/android/src/main/res/xml/app_restrictions.xml
@@ -122,4 +122,10 @@
         android:key="IncludedPackageNames"
         android:restrictionType="string"
         android:title="@string/included_packages" />
+
+    <restriction
+        android:description="@string/defines_an_auth_key_that_will_be_used_for_login"
+        android:key="AuthKey"
+        android:restrictionType="string"
+        android:title="@string/auth_key" />
 </restrictions>

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/mobile v0.0.0-20240319015410-c58ccf4b0c87
 	golang.org/x/sys v0.22.0
 	inet.af/netaddr v0.0.0-20220617031823-097006376321
-	tailscale.com v1.73.0-pre
+	tailscale.com v1.73.0-pre.0.20240821174438-af3d3c433b67
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -258,5 +258,5 @@ inet.af/netaddr v0.0.0-20220617031823-097006376321 h1:B4dC8ySKTQXasnjDTMsoCMf1sQ
 inet.af/netaddr v0.0.0-20220617031823-097006376321/go.mod h1:OIezDfdzOgFhuw4HuWapWq2e9l0H9tK4F1j+ETRtF3k=
 software.sslmate.com/src/go-pkcs12 v0.4.0 h1:H2g08FrTvSFKUj+D309j1DPfk5APnIdAQAB8aEykJ5k=
 software.sslmate.com/src/go-pkcs12 v0.4.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=
-tailscale.com v1.73.0-pre h1:l2Untm8MV8pqZEpcyy6OAJZ9TvKNWPK2VD/oes8STvk=
-tailscale.com v1.73.0-pre/go.mod h1:v7OHtg0KLAnhOVf81Z8WrjNefj238QbFhgkWJQoKxbs=
+tailscale.com v1.73.0-pre.0.20240821174438-af3d3c433b67 h1:QiC96H1MvmzSjMn1Bs5oboovD+qXRecko3sJhbOfEr8=
+tailscale.com v1.73.0-pre.0.20240821174438-af3d3c433b67/go.mod h1:v7OHtg0KLAnhOVf81Z8WrjNefj238QbFhgkWJQoKxbs=


### PR DESCRIPTION
Updates tailscale/tailscale#1572

This PR defines the AuthKey system policy in the Android codebase, allowing the code in OSS (see tailscale/tailscale#13061) to pick up any value defined by an MDM solution via managed app configuration. It also adds the new key to the `app_restrictions.xml`.