### PR TITLE
android: Allow notification dismissed via swipe on Android 13

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/App.kt
+++ b/android/src/main/java/com/tailscale/ipn/App.kt
@@ -500,6 +500,7 @@ open class UninitializedApp : Application() {
         .setOnlyAlertOnce(!vpnRunning)
         .setOngoing(vpnRunning)
         .setSilent(true)
+        .setOngoing(false)
         .setPriority(NotificationCompat.PRIORITY_DEFAULT)
         .addAction(NotificationCompat.Action.Builder(0, actionLabel, pendingButtonIntent).build())
         .setContentIntent(pendingIntent)


### PR DESCRIPTION
Resolves: https://github.com/tailscale/tailscale/issues/12132

* Allows notification to be dismissed on Android 13 with the swipe gesture
  * Sets `.setOngoing(false)` to be able to dismiss the notification, [docs](https://developer.android.com/reference/android/app/Notification.Builder#setOngoing(boolean))

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/8295a035-3133-43b0-8f12-98c6d94b68e4" /> | <video src="https://github.com/user-attachments/assets/4aa26a54-cdd3-4cfa-bdda-9662beb4a597" /> |

















