### PR TITLE
android: stop tailscaled when VPN has been revoked

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/MainActivity.kt
+++ b/android/src/main/java/com/tailscale/ipn/MainActivity.kt
@@ -89,7 +89,7 @@ class MainActivity : ComponentActivity() {
   private lateinit var vpnPermissionLauncher: ActivityResultLauncher<Intent>
   private val viewModel: MainViewModel by lazy {
     val app = App.get()
-    vpnViewModel = app.vpnViewModel
+    vpnViewModel = app.getAppScopedViewModel()
     ViewModelProvider(this, MainViewModelFactory(vpnViewModel)).get(MainViewModel::class.java)
   }
   private lateinit var vpnViewModel: VpnViewModel
@@ -137,7 +137,7 @@ class MainActivity : ComponentActivity() {
               showOtherVPNConflictDialog()
             } else {
               Log.d("VpnPermission", "Permission was denied by the user")
-              viewModel.setVpnPrepared(false)
+              vpnViewModel.setVpnPrepared(false)
             }
           }
         }

--- a/android/src/main/java/com/tailscale/ipn/NetworkChangeCallback.kt
+++ b/android/src/main/java/com/tailscale/ipn/NetworkChangeCallback.kt
@@ -1,0 +1,58 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+package com.tailscale.ipn
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.LinkProperties
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import android.util.Log
+import libtailscale.Libtailscale
+import java.net.InetAddress
+import java.net.NetworkInterface
+
+object NetworkChangeCallback {
+
+  // requestNetwork attempts to find the best network that matches the passed NetworkRequest. It is
+  // possible that this might return an unusuable network, eg a captive portal.
+  fun monitorDnsChanges(connectivityManager: ConnectivityManager, dns: DnsConfig) {
+    val networkConnectivityRequest =
+        NetworkRequest.Builder()
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN)
+            .build()
+
+    connectivityManager.registerNetworkCallback(
+        networkConnectivityRequest,
+        object : ConnectivityManager.NetworkCallback() {
+          override fun onAvailable(network: Network) {
+            super.onAvailable(network)
+
+            val sb = StringBuilder()
+            val linkProperties: LinkProperties? = connectivityManager.getLinkProperties(network)
+            val dnsList: MutableList<InetAddress> = linkProperties?.dnsServers ?: mutableListOf()
+            for (ip in dnsList) {
+              sb.append(ip.hostAddress).append(" ")
+            }
+            val searchDomains: String? = linkProperties?.domains
+            if (searchDomains != null) {
+              sb.append("\n")
+              sb.append(searchDomains)
+            }
+
+            if (dns.updateDNSFromNetwork(sb.toString())) {
+              Libtailscale.onDNSConfigChanged(linkProperties?.interfaceName)
+            }
+          }
+
+          override fun onLost(network: Network) {
+            super.onLost(network)
+            if (dns.updateDNSFromNetwork("")) {
+              Libtailscale.onDNSConfigChanged("")
+            }
+          }
+        })
+  }
+}

--- a/android/src/main/java/com/tailscale/ipn/ui/model/Ipn.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/model/Ipn.kt
@@ -18,7 +18,11 @@ class Ipn {
     NeedsMachineAuth(3),
     Stopped(4),
     Starting(5),
-    Running(6);
+    Running(6),
+    // Stopping represents a state where a request to stop Tailscale has been issue but has not
+    // completed. This state allows UI to optimistically reflect a stopped state, and to fallback if
+    // necessary.
+    Stopping(7);
 
     companion object {
       fun fromInt(value: Int): State {

--- a/android/src/main/java/com/tailscale/ipn/ui/notifier/Notifier.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/notifier/Notifier.kt
@@ -33,7 +33,8 @@ object Notifier {
   private val decoder = Json { ignoreUnknownKeys = true }
 
   // General IPN Bus State
-  val state: StateFlow<Ipn.State> = MutableStateFlow(Ipn.State.NoState)
+  private val _state = MutableStateFlow(Ipn.State.NoState)
+  val state: StateFlow<Ipn.State> = _state
   val netmap: StateFlow<Netmap.NetworkMap?> = MutableStateFlow(null)
   val prefs: StateFlow<Ipn.Prefs?> = MutableStateFlow(null)
   val engineStatus: StateFlow<Ipn.EngineStatus?> = MutableStateFlow(null)
@@ -68,22 +69,22 @@ object Notifier {
               NotifyWatchOpt.Prefs.value or
               NotifyWatchOpt.InitialState.value or
                   NotifyWatchOpt.InitialHealthState.value
-      manager =
-          app.watchNotifications(mask.toLong()) { notification ->
-            val notify = decoder.decodeFromStream<Notify>(notification.inputStream())
-            notify.State?.let { state.set(Ipn.State.fromInt(it)) }
-            notify.NetMap?.let(netmap::set)
-            notify.Prefs?.let(prefs::set)
-            notify.Engine?.let(engineStatus::set)
-            notify.TailFSShares?.let(tailFSShares::set)
-            notify.BrowseToURL?.let(browseToURL::set)
-            notify.LoginFinished?.let { loginFinished.set(it.property) }
-            notify.Version?.let(version::set)
-            notify.OutgoingFiles?.let(outgoingFiles::set)
-            notify.FilesWaiting?.let(filesWaiting::set)
-            notify.IncomingFiles?.let(incomingFiles::set)
-            notify.Health?.let(health::set)
-          }
+                  manager =
+                  app.watchNotifications(mask.toLong()) { notification ->
+                      val notify = decoder.decodeFromStream<Notify>(notification.inputStream())
+                      notify.State?.let { state.set(Ipn.State.fromInt(it)) }
+                      notify.NetMap?.let(netmap::set)
+                      notify.Prefs?.let(prefs::set)
+                      notify.Engine?.let(engineStatus::set)
+                      notify.TailFSShares?.let(tailFSShares::set)
+                      notify.BrowseToURL?.let(browseToURL::set)
+                      notify.LoginFinished?.let { loginFinished.set(it.property) }
+                      notify.Version?.let(version::set)
+                      notify.OutgoingFiles?.let(outgoingFiles::set)
+                      notify.FilesWaiting?.let(filesWaiting::set)
+                      notify.IncomingFiles?.let(incomingFiles::set)
+                      notify.Health?.let(health::set)
+                  }
     }
   }
 
@@ -107,4 +108,8 @@ object Notifier {
     InitialOutgoingFiles(64),
     InitialHealthState(128),
   }
+
+  fun setState(newState: Ipn.State) {
+    _state.value = newState
+}
 }

--- a/android/src/main/java/com/tailscale/ipn/ui/view/MainView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/MainView.kt
@@ -232,6 +232,9 @@ fun MainView(
                 ConnectView(
                     state,
                     isPrepared,
+                    // If Tailscale is stopping, don't automatically restart; wait for user to take
+                    // action (eg, if the user connected to another VPN).
+                    state != Ipn.State.Stopping,
                     user,
                     { viewModel.toggleVpn() },
                     { viewModel.login() },
@@ -407,6 +410,7 @@ fun StartingView() {
 fun ConnectView(
     state: Ipn.State,
     isPrepared: Boolean,
+    shouldStartAutomatically: Boolean,
     user: IpnLocal.LoginProfile?,
     connectAction: () -> Unit,
     loginAction: () -> Unit,
@@ -415,7 +419,7 @@ fun ConnectView(
     showVPNPermissionLauncherIfUnauthorized: () -> Unit
 ) {
   LaunchedEffect(isPrepared) {
-    if (!isPrepared) {
+    if (!isPrepared && shouldStartAutomatically) {
       showVPNPermissionLauncherIfUnauthorized()
     }
   }

--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/IpnViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/IpnViewModel.kt
@@ -134,11 +134,6 @@ open class IpnViewModel : ViewModel() {
   }
 
   // VPN Control
-
-  fun setVpnPrepared(prepared: Boolean) {
-    _vpnPrepared.value = prepared
-  }
-
   fun startVPN() {
     UninitializedApp.get().startVPN()
   }

--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/VpnViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/VpnViewModel.kt
@@ -26,9 +26,12 @@ class VpnViewModelFactory(private val application: Application) : ViewModelProvi
 // application scoped because Tailscale might be toggled on and off outside of the activity
 // lifecycle.
 class VpnViewModel(application: Application) : AndroidViewModel(application) {
-  // Whether the VPN is prepared
+  // Whether the VPN is prepared. This is set to true if the VPN application is already prepared, or if the user has previously consented to the VPN application. This is used to determine whether a VPN permission launcher needs to be shown. 
   val _vpnPrepared = MutableStateFlow(false)
   val vpnPrepared: StateFlow<Boolean> = _vpnPrepared
+  // Whether a VPN interface has been established. This is set by net.updateTUN upon VpnServiceBuilder.establish, and consumed by UI to reflect VPN state. 
+  val _vpnActive = MutableStateFlow(false)
+  val vpnActive: StateFlow<Boolean> = _vpnActive
   val TAG = "VpnViewModel"
 
   init {
@@ -49,7 +52,11 @@ class VpnViewModel(application: Application) : AndroidViewModel(application) {
     }
   }
 
-  fun setVpnPrepared(prepared: Boolean) {
-    _vpnPrepared.value = prepared
+  fun setVpnActive(isActive: Boolean) {
+    _vpnActive.value = isActive
+  }
+
+  fun setVpnPrepared(isPrepared: Boolean) {
+    _vpnPrepared.value = isPrepared
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.22.0
 require (
 	github.com/tailscale/wireguard-go v0.0.0-20240731203015-71393c576b98
 	golang.org/x/mobile v0.0.0-20240319015410-c58ccf4b0c87
-	golang.org/x/sys v0.22.0
 	inet.af/netaddr v0.0.0-20220617031823-097006376321
 	tailscale.com v1.73.0-pre.0.20240821174438-af3d3c433b67
 )
@@ -87,6 +86,7 @@ require (
 	golang.org/x/mod v0.19.0 // indirect
 	golang.org/x/net v0.27.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
+	golang.org/x/sys v0.22.0 // indirect
 	golang.org/x/term v0.22.0 // indirect
 	golang.org/x/text v0.16.0 // indirect
 	golang.org/x/time v0.5.0 // indirect

--- a/libtailscale/interfaces.go
+++ b/libtailscale/interfaces.go
@@ -3,7 +3,9 @@
 
 package libtailscale
 
-import _ "golang.org/x/mobile/bind"
+import (
+	_ "golang.org/x/mobile/bind"
+)
 
 // Start starts the application, storing state in the given dataDir and using
 // the given appCtx.
@@ -73,6 +75,8 @@ type IPNService interface {
 	NewBuilder() VPNServiceBuilder
 
 	Close()
+
+	UpdateVpnStatus(bool)
 }
 
 // VPNServiceBuilder corresponds to Android's VpnService.Builder.


### PR DESCRIPTION
-add new Ipn UI state 'Stopping' to handle the case where the VPN is no longer active and a request to stop Tailscale has been issued (but is not complete yet) and use for optimistic UI 
-when VPN has been revoked, stop tailscaled and set the state to Stopping 
-this fixes the race condition where when we tell tailscaled to stop, stopping races against the netmap state updating as a result of the VPN being revoked 
-add isActive state and use instead of isPrepared for UI showing whether we are connected - we were previously using isPrepared as a proxy for connection, but sometimes the VPN has been prepared but is not active (eg when VPN permissions have been given and VPN has been connected previously, but has been revoked) 
-refactor network callbacks into its own class for readability

Fixes tailscale/tailscale#12850