### PR TITLE
android: Prevent reauthenticate from being clicked multiple times

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/MainActivity.kt
+++ b/android/src/main/java/com/tailscale/ipn/MainActivity.kt
@@ -339,6 +339,8 @@ class MainActivity : ComponentActivity() {
   private fun login(urlString: String) {
     // Launch coroutine to listen for state changes. When the user completes login, relaunch
     // MainActivity to bring the app back to focus.
+      viewModel.setLoggingIn(false)
+
     App.get().applicationScope.launch {
       try {
         Notifier.state.collect { state ->

--- a/android/src/main/java/com/tailscale/ipn/ui/view/UserSwitcherView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/UserSwitcherView.kt
@@ -50,6 +50,7 @@ fun UserSwitcherView(nav: UserSwitcherNav, viewModel: UserSwitcherViewModel = vi
   val users by viewModel.loginProfiles.collectAsState()
   val currentUser by viewModel.loggedInUser.collectAsState()
   val showHeaderMenu by viewModel.showHeaderMenu.collectAsState()
+    val isLoggingIn by viewModel.isLogginIn.collectAsState()
 
   Scaffold(
       topBar = {
@@ -122,7 +123,10 @@ fun UserSwitcherView(nav: UserSwitcherNav, viewModel: UserSwitcherViewModel = vi
                   }
 
                   Lists.ItemDivider()
-                  Setting.Text(R.string.reauthenticate) { viewModel.login() }
+                  Setting.Text(
+                      R.string.reauthenticate,
+                      enabled = !isLoggingIn
+                  ) { viewModel.login() }
 
                   if (currentUser != null) {
                     Lists.ItemDivider()


### PR DESCRIPTION
Resolves: https://github.com/tailscale/tailscale/issues/13375

* Uses `isLoggingIn` state in the ViewModel to keep track if we are in progress of logging in.
  * There was no throttling or state to keep track if the button was enabled or not. Clicking the button rapidly caused the auth flow to keep resetting.
  
> [!NOTE]  
> A better UX experience would have the button be a disabled color or a screen loading state to indicate to the user that something is happening. I didn't see a similar pattern in the app.

https://github.com/user-attachments/assets/32a53761-efb4-4233-86d5-1fdd74a0476f

**Testing steps**
1. Login to Tailscale
2. Click your profile icon
3. Click your account
4. Click "Reauthenticate" rapidly
5. Observe

**Expected results:**
* You should only be able to tap the button once before the browser comes up
* When the broswer comes up and you close it, you should still be able to auth again
* After finishing auth, you should be able to click auth again
* After a failure, you should be able to click auth again