### PR TITLE
android: fix BuildConfig infinite loop

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/App.kt
+++ b/android/src/main/java/com/tailscale/ipn/App.kt
@@ -38,7 +38,6 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import libtailscale.BuildConfig as GoBuildConfig
 import libtailscale.Libtailscale
 import java.io.File
 import java.io.IOException
@@ -79,6 +78,8 @@ class App : UninitializedApp(), libtailscale.AppContext, ViewModelStoreOwner {
   override fun getPlatformDNSConfig(): String = dns.dnsConfigAsString
 
   override fun isPlayVersion(): Boolean = MaybeGoogle.isGoogle()
+
+  override fun shouldUseGoogleDNSFallback() : Boolean = BuildConfig.USE_GOOGLE_DNS_FALLBACK
 
   override fun log(s: String, s1: String) {
     Log.d(s, s1)
@@ -310,13 +311,6 @@ class App : UninitializedApp(), libtailscale.AppContext, ViewModelStoreOwner {
       Log.d("MDM", "$key value cannot be serialized to JSON. Throwing NoSuchKeyException.")
       throw MDMSettings.NoSuchKeyException()
     }
-  }
-
-  // getBuildConfig implements the libtailscale.AppContext interface.
-  override fun getBuildConfig(): GoBuildConfig {
-    var buildConfig = GoBuildConfig()
-    buildConfig.useGoogleDNSFallback = BuildConfig.USE_GOOGLE_DNS_FALLBACK
-    return buildConfig
   }
 
   fun notifyPolicyChanged() {

--- a/libtailscale/backend.go
+++ b/libtailscale/backend.go
@@ -44,9 +44,6 @@ type App struct {
 	// appCtx is a global reference to the com.tailscale.ipn.App instance.
 	appCtx AppContext
 
-	// buildConfig is the build configuration for the app.
-	buildConfig *BuildConfig
-
 	store             *stateStore
 	policyStore       *syspolicyHandler
 	logIDPublicAtomic atomic.Pointer[logid.PublicID]
@@ -100,8 +97,7 @@ type backend struct {
 	// when no nameservers are provided by Tailscale.
 	avoidEmptyDNS bool
 
-	appCtx      AppContext
-	buildConfig *BuildConfig
+	appCtx AppContext
 }
 
 type settingsFunc func(*router.Config, *dns.OSConfig) error
@@ -266,10 +262,9 @@ func (a *App) newBackend(dataDir, directFileRoot string, appCtx AppContext, stor
 
 	logf := logger.RusagePrefixLog(log.Printf)
 	b := &backend{
-		devices:     newTUNDevices(),
-		settings:    settings,
-		appCtx:      appCtx,
-		buildConfig: a.buildConfig,
+		devices:  newTUNDevices(),
+		settings: settings,
+		appCtx:   appCtx,
 	}
 	var logID logid.PrivateID
 	logID.UnmarshalText([]byte("dead0000dead0000dead0000dead0000dead0000dead0000dead0000dead0000"))

--- a/libtailscale/interfaces.go
+++ b/libtailscale/interfaces.go
@@ -37,6 +37,9 @@ type AppContext interface {
 	// (as opposed to F-droid/sideloaded).
 	IsPlayVersion() bool
 
+	// ShouldUseGoogleDNSFallback reports whether or not to use Google for DNS fallback.
+	ShouldUseGoogleDNSFallback() bool
+
 	// IsChromeOS reports whether we're on a ChromeOS device.
 	IsChromeOS() (bool, error)
 
@@ -57,12 +60,6 @@ type AppContext interface {
 	// GetSyspolicyStringArrayValue returns the current string array value for the given system policy,
 	// expressed as a JSON string.
 	GetSyspolicyStringArrayJSONValue(key string) (string, error)
-
-	// GetBuildConfig gets the build configuration of the Android app.
-	//
-	// The returned BuildConfig should not change during the lifetime of
-	// the app.
-	GetBuildConfig() *BuildConfig
 }
 
 // IPNService corresponds to our IPNService in Java.
@@ -171,12 +168,4 @@ func RequestVPN(service IPNService) {
 
 func ServiceDisconnect(service IPNService) {
 	onDisconnect <- service
-}
-
-// BuildConfig is a struct that represents the build configuration of the
-// Android application, as set in BuildConfig.java.
-type BuildConfig struct {
-	// UseGoogleDNSFallback is whether to fall back to the Google public
-	// DNS servers if the platform's DNS servers cannot be determined.
-	UseGoogleDNSFallback bool
 }

--- a/libtailscale/net.go
+++ b/libtailscale/net.go
@@ -287,7 +287,7 @@ func (b *backend) getDNSBaseConfig() (ret dns.OSConfig, _ error) {
 		// DNS config are lacking, and almost all Android phones use Google
 		// services anyway, so it's a reasonable default: it's an ecosystem the
 		// user has selected by having an Android device.
-		if len(ret.Nameservers) == 0 && b.buildConfig.UseGoogleDNSFallback {
+		if len(ret.Nameservers) == 0 && b.appCtx.ShouldUseGoogleDNSFallback() {
 			log.Printf("getDNSBaseConfig: none found; falling back to Google public DNS")
 			ret.Nameservers = append(ret.Nameservers, googleDNSServers...)
 		}

--- a/libtailscale/tailscale.go
+++ b/libtailscale/tailscale.go
@@ -38,11 +38,6 @@ func newApp(dataDir, directFileRoot string, appCtx AppContext) Application {
 	}
 	a.ready.Add(2)
 
-	// Get the build configuration, if any.
-	if bc := appCtx.GetBuildConfig(); bc != nil {
-		a.buildConfig = bc
-	}
-
 	a.store = newStateStore(a.appCtx)
 	a.policyStore = &syspolicyHandler{a: a}
 	netmon.RegisterInterfaceGetter(a.getInterfaces)


### PR DESCRIPTION
Rather than create a Go struct that is set by Android, have Go call into Android to fetch build BuildConfig Updates tailscale/tailscale#13431