### PR TITLE
android: add logging for network change callbacks

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/App.kt
+++ b/android/src/main/java/com/tailscale/ipn/App.kt
@@ -108,6 +108,7 @@ class App : UninitializedApp(), libtailscale.AppContext, ViewModelStoreOwner {
 
   override fun onTerminate() {
     super.onTerminate()
+    NetworkChangeCallback.stopLoggingLinkChanges(connectivityManager)
     Notifier.stop()
     notificationManager.cancelAll()
     applicationScope.cancel()
@@ -137,6 +138,7 @@ class App : UninitializedApp(), libtailscale.AppContext, ViewModelStoreOwner {
     healthNotifier = HealthNotifier(Notifier.health, applicationScope)
     connectivityManager = this.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
     NetworkChangeCallback.monitorDnsChanges(connectivityManager, dns)
+    NetworkChangeCallback.logLinkChanges(connectivityManager)
     initViewModels()
     applicationScope.launch {
       Notifier.state.collect { state ->


### PR DESCRIPTION
This adds verbose logs for exactly what happens when we get callbacks for networks changing.