### PR TITLE
Makefile: disable GOTOOLCHAIN from dynamic switching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,10 @@ AVD ?= tailscale-$(HOST_ARCH)
 export AVD_IMAGE
 export AVD
 
+# Use our toolchain or the one that is specified, do not perform dynamic toolchain switching.
+GOTOOLCHAIN=local
+export GOTOOLCHAIN
+
 # TOOLCHAINDIR is set by fdoid CI and used by tool/* scripts.
 TOOLCHAINDIR ?=
 export TOOLCHAINDIR


### PR DESCRIPTION
Go has a new build facility that can utilize other toolchains if a module says so, but we manage the toolchain in our own way, so disable it.

Updates #501