### PR TITLE
Makefile: remove go toolchain version marker in clean as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,10 @@ AVD ?= tailscale-$(HOST_ARCH)
 export AVD_IMAGE
 export AVD
 
+# Use our toolchain or the one that is specified, do not perform dynamic toolchain switching.
+GOTOOLCHAIN=local
+export GOTOOLCHAIN
+
 # TOOLCHAINDIR is set by fdoid CI and used by tool/* scripts.
 TOOLCHAINDIR ?=
 export TOOLCHAINDIR

--- a/Makefile
+++ b/Makefile
@@ -313,7 +313,7 @@ clean: ## Remove build artifacts.  Does not purge docker build envs.  Use docker
 	@echo "Cleaning up old build artifacts"
 	-rm -rf android/build $(DEBUG_APK) $(RELEASE_AAB) $(RELEASE_TV_AAB) $(LIBTAILSCALE) android/libs *.apk *.aab
 	@echo "Cleaning cached toolchain"
-	-rm -rf $(HOME)/.cache/tailscale-go
+	-rm -rf $(HOME)/.cache/tailscale-go{,.extracted}
 	-pkill -f gradle
 
 .PHONY: help


### PR DESCRIPTION
The go wrapper script in tool/go assumes that .extracted is representative of the state of the toolchain directory, so it must be removed when the toolchain directory is removed.

Updates #501