### PR TITLE
android: send Android logs to logz

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -160,6 +160,9 @@ dependencies {
 
     // Unit Tests
     testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.mockito:mockito-core:5.4.0'
+    testImplementation 'org.mockito:mockito-inline:5.2.0'
+    testImplementation 'org.mockito.kotlin:mockito-kotlin:5.4.0'
 
     debugImplementation("androidx.compose.ui:ui-tooling")
     implementation("androidx.compose.ui:ui-tooling-preview")

--- a/android/src/main/java/com/tailscale/ipn/App.kt
+++ b/android/src/main/java/com/tailscale/ipn/App.kt
@@ -31,6 +31,7 @@ import com.tailscale.ipn.ui.notifier.HealthNotifier
 import com.tailscale.ipn.ui.notifier.Notifier
 import com.tailscale.ipn.ui.viewModel.VpnViewModel
 import com.tailscale.ipn.ui.viewModel.VpnViewModelFactory
+import com.tailscale.ipn.util.TSLog
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -79,7 +80,7 @@ class App : UninitializedApp(), libtailscale.AppContext, ViewModelStoreOwner {
 
   override fun isPlayVersion(): Boolean = MaybeGoogle.isGoogle()
 
-  override fun shouldUseGoogleDNSFallback() : Boolean = BuildConfig.USE_GOOGLE_DNS_FALLBACK
+  override fun shouldUseGoogleDNSFallback(): Boolean = BuildConfig.USE_GOOGLE_DNS_FALLBACK
 
   override fun log(s: String, s1: String) {
     Log.d(s, s1)
@@ -162,7 +163,7 @@ class App : UninitializedApp(), libtailscale.AppContext, ViewModelStoreOwner {
       result.fold(
           onSuccess = {},
           onFailure = { error ->
-            Log.d("TAG", "Set want running: failed to update preferences: ${error.message}")
+            TSLog.d("TAG", "Set want running: failed to update preferences: ${error.message}")
           })
     }
     Client(applicationScope)
@@ -203,7 +204,7 @@ class App : UninitializedApp(), libtailscale.AppContext, ViewModelStoreOwner {
   private fun updateConnStatus(ableToStartVPN: Boolean) {
     setAbleToStartVPN(ableToStartVPN)
     QuickToggleService.updateTile()
-    Log.d("App", "Set Tile Ready: $ableToStartVPN")
+    TSLog.d("App", "Set Tile Ready: $ableToStartVPN")
   }
 
   override fun getModelName(): String {
@@ -266,14 +267,14 @@ class App : UninitializedApp(), libtailscale.AppContext, ViewModelStoreOwner {
         downloads.mkdirs()
       }
     } catch (e: Exception) {
-      Log.e(TAG, "Failed to create downloads folder: $e")
+      TSLog.e(TAG, "Failed to create downloads folder: $e")
       downloads = File(this.filesDir, "Taildrop")
       try {
         if (!downloads.exists()) {
           downloads.mkdirs()
         }
       } catch (e: Exception) {
-        Log.e(TAG, "Failed to create Taildrop folder: $e")
+        TSLog.e(TAG, "Failed to create Taildrop folder: $e")
         downloads = File("")
       }
     }
@@ -308,7 +309,7 @@ class App : UninitializedApp(), libtailscale.AppContext, ViewModelStoreOwner {
       val list = setting.value as? List<*>
       return Json.encodeToString(list)
     } catch (e: Exception) {
-      Log.d("MDM", "$key value cannot be serialized to JSON. Throwing NoSuchKeyException.")
+      TSLog.d("MDM", "$key value cannot be serialized to JSON. Throwing NoSuchKeyException.")
       throw MDMSettings.NoSuchKeyException()
     }
   }
@@ -373,13 +374,13 @@ open class UninitializedApp : Application() {
     try {
       startForegroundService(intent)
     } catch (foregroundServiceStartException: IllegalStateException) {
-      Log.e(
+      TSLog.e(
           TAG,
           "startVPN hit ForegroundServiceStartNotAllowedException in startForegroundService(): $foregroundServiceStartException")
     } catch (securityException: SecurityException) {
-      Log.e(TAG, "startVPN hit SecurityException in startForegroundService(): $securityException")
+      TSLog.e(TAG, "startVPN hit SecurityException in startForegroundService(): $securityException")
     } catch (e: Exception) {
-      Log.e(TAG, "startVPN hit exception in startForegroundService(): $e")
+      TSLog.e(TAG, "startVPN hit exception in startForegroundService(): $e")
     }
   }
 
@@ -388,9 +389,9 @@ open class UninitializedApp : Application() {
     try {
       startService(intent)
     } catch (illegalStateException: IllegalStateException) {
-      Log.e(TAG, "stopVPN hit IllegalStateException in startService(): $illegalStateException")
+      TSLog.e(TAG, "stopVPN hit IllegalStateException in startService(): $illegalStateException")
     } catch (e: Exception) {
-      Log.e(TAG, "stopVPN hit exception in startService(): $e")
+      TSLog.e(TAG, "stopVPN hit exception in startService(): $e")
     }
   }
 
@@ -465,7 +466,7 @@ open class UninitializedApp : Application() {
 
   fun addUserDisallowedPackageName(packageName: String) {
     if (packageName.isEmpty()) {
-      Log.e(TAG, "addUserDisallowedPackageName called with empty packageName")
+      TSLog.e(TAG, "addUserDisallowedPackageName called with empty packageName")
       return
     }
 
@@ -480,7 +481,7 @@ open class UninitializedApp : Application() {
 
   fun removeUserDisallowedPackageName(packageName: String) {
     if (packageName.isEmpty()) {
-      Log.e(TAG, "removeUserDisallowedPackageName called with empty packageName")
+      TSLog.e(TAG, "removeUserDisallowedPackageName called with empty packageName")
       return
     }
 
@@ -498,7 +499,7 @@ open class UninitializedApp : Application() {
     val mdmDisallowed =
         MDMSettings.excludedPackages.flow.value.value?.split(",")?.map { it.trim() } ?: emptyList()
     if (mdmDisallowed.isNotEmpty()) {
-      Log.d(TAG, "Excluded application packages were set via MDM: $mdmDisallowed")
+      TSLog.d(TAG, "Excluded application packages were set via MDM: $mdmDisallowed")
       return builtInDisallowedPackageNames + mdmDisallowed
     }
     val userDisallowed =

--- a/android/src/main/java/com/tailscale/ipn/IPNService.kt
+++ b/android/src/main/java/com/tailscale/ipn/IPNService.kt
@@ -8,10 +8,10 @@ import android.content.pm.PackageManager
 import android.net.VpnService
 import android.os.Build
 import android.system.OsConstants
-import android.util.Log
 import com.tailscale.ipn.mdm.MDMSettings
 import com.tailscale.ipn.ui.model.Ipn
 import com.tailscale.ipn.ui.notifier.Notifier
+import com.tailscale.ipn.util.TSLog
 import libtailscale.Libtailscale
 import java.util.UUID
 
@@ -97,7 +97,7 @@ open class IPNService : VpnService(), libtailscale.IPNService {
           UninitializedApp.STATUS_NOTIFICATION_ID,
           UninitializedApp.get().buildStatusNotification(true))
     } catch (e: Exception) {
-      Log.e(TAG, "Failed to start foreground service: $e")
+      TSLog.e(TAG, "Failed to start foreground service: $e")
     }
   }
 
@@ -113,7 +113,7 @@ open class IPNService : VpnService(), libtailscale.IPNService {
     try {
       b.addDisallowedApplication(name)
     } catch (e: PackageManager.NameNotFoundException) {
-      Log.d(TAG, "Failed to add disallowed application: $e")
+      TSLog.d(TAG, "Failed to add disallowed application: $e")
     }
   }
 
@@ -135,7 +135,7 @@ open class IPNService : VpnService(), libtailscale.IPNService {
       // Tailscale,
       // then only allow those apps.
       for (packageName in includedPackages) {
-        Log.d(TAG, "Including app: $packageName")
+        TSLog.d(TAG, "Including app: $packageName")
         b.addAllowedApplication(packageName)
       }
     } else {
@@ -143,7 +143,7 @@ open class IPNService : VpnService(), libtailscale.IPNService {
       // - any app that the user manually disallowed in the GUI
       // - any app that we disallowed via hard-coding
       for (disallowedPackageName in UninitializedApp.get().disallowedPackageNames()) {
-        Log.d(TAG, "Disallowing app: $disallowedPackageName")
+        TSLog.d(TAG, "Disallowing app: $disallowedPackageName")
         disallowApp(b, disallowedPackageName)
       }
     }

--- a/android/src/main/java/com/tailscale/ipn/MainActivity.kt
+++ b/android/src/main/java/com/tailscale/ipn/MainActivity.kt
@@ -16,7 +16,6 @@ import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.os.Bundle
 import android.provider.Settings
-import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.ActivityResultLauncher
@@ -78,6 +77,7 @@ import com.tailscale.ipn.ui.viewModel.MainViewModelFactory
 import com.tailscale.ipn.ui.viewModel.PingViewModel
 import com.tailscale.ipn.ui.viewModel.SettingsNav
 import com.tailscale.ipn.ui.viewModel.VpnViewModel
+import com.tailscale.ipn.util.TSLog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -128,15 +128,15 @@ class MainActivity : ComponentActivity() {
     vpnPermissionLauncher =
         registerForActivityResult(VpnPermissionContract()) { granted ->
           if (granted) {
-            Log.d("VpnPermission", "VPN permission granted")
+            TSLog.d("VpnPermission", "VPN permission granted")
             vpnViewModel.setVpnPrepared(true)
             App.get().startVPN()
           } else {
             if (isAnotherVpnActive(this)) {
-              Log.d("VpnPermission", "Another VPN is likely active")
+              TSLog.d("VpnPermission", "Another VPN is likely active")
               showOtherVPNConflictDialog()
             } else {
-              Log.d("VpnPermission", "Permission was denied by the user")
+              TSLog.d("VpnPermission", "Permission was denied by the user")
               vpnViewModel.setVpnPrepared(false)
             }
           }
@@ -357,7 +357,7 @@ class MainActivity : ComponentActivity() {
           }
         }
       } catch (e: Exception) {
-        Log.e(TAG, "Login: failed to start MainActivity: $e")
+        TSLog.e(TAG, "Login: failed to start MainActivity: $e")
       }
     }
 
@@ -371,7 +371,7 @@ class MainActivity : ComponentActivity() {
         val fallbackIntent = Intent(Intent.ACTION_VIEW, url)
         startActivity(fallbackIntent)
       } catch (e: Exception) {
-        Log.e(TAG, "Login: failed to open browser: $e")
+        TSLog.e(TAG, "Login: failed to open browser: $e")
       }
     }
   }

--- a/android/src/main/java/com/tailscale/ipn/NetworkChangeCallback.kt
+++ b/android/src/main/java/com/tailscale/ipn/NetworkChangeCallback.kt
@@ -8,6 +8,7 @@ import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import android.util.Log
+import com.tailscale.ipn.util.TSLog
 import libtailscale.Libtailscale
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
@@ -47,7 +48,7 @@ object NetworkChangeCallback {
           override fun onAvailable(network: Network) {
             super.onAvailable(network)
 
-            Log.d(TAG, "onAvailable: network ${network}")
+            TSLog.d(TAG, "onAvailable: network ${network}")
             lock.withLock {
               activeNetworks[network] = NetworkInfo(NetworkCapabilities(), LinkProperties())
             }
@@ -69,7 +70,7 @@ object NetworkChangeCallback {
           override fun onLost(network: Network) {
             super.onLost(network)
 
-            Log.d(TAG, "onLost: network ${network}")
+            TSLog.d(TAG, "onLost: network ${network}")
             lock.withLock {
               activeNetworks.remove(network)
               maybeUpdateDNSConfig("onLost", dns)
@@ -137,7 +138,7 @@ object NetworkChangeCallback {
   private fun maybeUpdateDNSConfig(why: String, dns: DnsConfig) {
     val defaultNetwork = pickDefaultNetwork()
     if (defaultNetwork == null) {
-      Log.d(TAG, "${why}: no default network available; not updating DNS config")
+      TSLog.d(TAG, "${why}: no default network available; not updating DNS config")
       return
     }
     val info = activeNetworks[defaultNetwork]
@@ -158,7 +159,7 @@ object NetworkChangeCallback {
       sb.append(searchDomains)
     }
     if (dns.updateDNSFromNetwork(sb.toString())) {
-      Log.d(
+      TSLog.d(
           TAG,
           "${why}: updated DNS config for network ${defaultNetwork} (${info.linkProps.interfaceName})")
       Libtailscale.onDNSConfigChanged(info.linkProps.interfaceName)

--- a/android/src/main/java/com/tailscale/ipn/ShareActivity.kt
+++ b/android/src/main/java/com/tailscale/ipn/ShareActivity.kt
@@ -8,7 +8,6 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.provider.OpenableColumns
-import android.util.Log
 import android.webkit.MimeTypeMap
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -20,6 +19,7 @@ import com.tailscale.ipn.ui.theme.AppTheme
 import com.tailscale.ipn.ui.util.set
 import com.tailscale.ipn.ui.util.universalFit
 import com.tailscale.ipn.ui.view.TaildropView
+import com.tailscale.ipn.util.TSLog
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlin.random.Random
@@ -59,7 +59,7 @@ class ShareActivity : ComponentActivity() {
   // Loads the files from the intent.
   fun loadFiles() {
     if (intent == null) {
-      Log.e(TAG, "Share failure - No intent found")
+      TSLog.e(TAG, "Share failure - No intent found")
       return
     }
 
@@ -83,7 +83,7 @@ class ShareActivity : ComponentActivity() {
             }
           }
           else -> {
-            Log.e(TAG, "No extras found in intent - nothing to share")
+            TSLog.e(TAG, "No extras found in intent - nothing to share")
             null
           }
         }
@@ -117,7 +117,7 @@ class ShareActivity : ComponentActivity() {
         } ?: emptyList()
 
     if (pendingFiles.isEmpty()) {
-      Log.e(TAG, "Share failure - no files extracted from intent")
+      TSLog.e(TAG, "Share failure - no files extracted from intent")
     }
 
     requestedTransfers.set(pendingFiles)

--- a/android/src/main/java/com/tailscale/ipn/StartVPNWorker.java
+++ b/android/src/main/java/com/tailscale/ipn/StartVPNWorker.java
@@ -15,6 +15,8 @@ import androidx.annotation.NonNull;
 import androidx.work.Worker;
 import androidx.work.WorkerParameters;
 
+import com.tailscale.ipn.util.TSLog;
+
 /**
  * A worker that exists to support IPNReceiver.
  */
@@ -38,7 +40,7 @@ public final class StartVPNWorker extends Worker {
         }
 
         // We aren't ready to start the VPN or don't have permission, open the Tailscale app.
-        android.util.Log.e("StartVPNWorker", "Tailscale isn't ready to start the VPN, notify the user.");
+        TSLog.e("StartVPNWorker", "Tailscale isn't ready to start the VPN, notify the user.");
 
         // Send notification
         NotificationManager notificationManager = (NotificationManager) app.getSystemService(Context.NOTIFICATION_SERVICE);

--- a/android/src/main/java/com/tailscale/ipn/ui/localapi/Client.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/localapi/Client.kt
@@ -4,7 +4,6 @@
 package com.tailscale.ipn.ui.localapi
 
 import android.content.Context
-import android.util.Log
 import com.tailscale.ipn.ui.model.BugReportID
 import com.tailscale.ipn.ui.model.Errors
 import com.tailscale.ipn.ui.model.Ipn
@@ -13,6 +12,7 @@ import com.tailscale.ipn.ui.model.IpnState
 import com.tailscale.ipn.ui.model.StableNodeID
 import com.tailscale.ipn.ui.model.Tailcfg
 import com.tailscale.ipn.ui.util.InputStreamAdapter
+import com.tailscale.ipn.util.TSLog
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -175,7 +175,7 @@ class Client(private val scope: CoroutineScope) {
           })
     } catch (e: Exception) {
       parts.forEach { it.body.close() }
-      Log.e(TAG, "Error creating file upload body: $e")
+      TSLog.e(TAG, "Error creating file upload body: $e")
       responseHandler(Result.failure(e))
       return
     }
@@ -307,7 +307,7 @@ class Request<T>(
   @OptIn(ExperimentalSerializationApi::class)
   fun execute() {
     scope.launch(Dispatchers.IO) {
-      Log.d(TAG, "Executing request:${method}:${fullPath} on app $app")
+      TSLog.d(TAG, "Executing request:${method}:${fullPath} on app $app")
       try {
         val resp =
             if (parts != null) app.callLocalAPIMultipart(timeoutMillis, method, fullPath, parts)
@@ -350,7 +350,7 @@ class Request<T>(
         // The response handler will invoked internally by the request parser
         scope.launch { responseHandler(response) }
       } catch (e: Exception) {
-        Log.e(TAG, "Error executing request:${method}:${fullPath}: $e")
+        TSLog.e(TAG, "Error executing request:${method}:${fullPath}: $e")
         scope.launch { responseHandler(Result.failure(e)) }
       }
     }

--- a/android/src/main/java/com/tailscale/ipn/ui/notifier/Notifier.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/notifier/Notifier.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
+import com.tailscale.ipn.util.TSLog
 
 // Notifier is a wrapper around the IPN Bus notifier.  It provides a way to watch
 // for changes in various parts of the Tailscale engine.  You will typically only use
@@ -59,7 +60,7 @@ object Notifier {
 
   @OptIn(ExperimentalSerializationApi::class)
   fun start(scope: CoroutineScope) {
-    Log.d(TAG, "Starting")
+    TSLog.d(TAG, "Starting Notifier")
     if (!::app.isInitialized) {
       App.get()
     }
@@ -89,7 +90,7 @@ object Notifier {
   }
 
   fun stop() {
-    Log.d(TAG, "Stopping")
+    TSLog.d(TAG, "Stopping Notifier")
     manager?.let {
       it.stop()
       manager = null

--- a/android/src/main/java/com/tailscale/ipn/ui/util/TimeUtil.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/util/TimeUtil.kt
@@ -3,8 +3,8 @@
 
 package com.tailscale.ipn.ui.util
 
-import android.util.Log
 import com.tailscale.ipn.R
+import com.tailscale.ipn.util.TSLog
 import java.time.Duration
 import java.time.Instant
 import java.time.format.DateTimeFormatter
@@ -108,12 +108,12 @@ object TimeUtil {
                 'm' -> durationFragment * 60.0
                 's' -> durationFragment
                 else -> {
-                  Log.e(TAG, "Invalid duration string: $goDuration")
+                  TSLog.e(TAG, "Invalid duration string: $goDuration")
                   return null
                 }
               }
         } catch (e: NumberFormatException) {
-          Log.e(TAG, "Invalid duration string: $goDuration")
+          TSLog.e(TAG, "Invalid duration string: $goDuration")
           return null
         }
         valStr = ""

--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/DNSSettingsViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/DNSSettingsViewModel.kt
@@ -3,7 +3,6 @@
 
 package com.tailscale.ipn.ui.viewModel
 
-import android.util.Log
 import androidx.annotation.StringRes
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -24,6 +23,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import com.tailscale.ipn.util.TSLog
 
 class DNSSettingsViewModelFactory : ViewModelProvider.Factory {
   @Suppress("UNCHECKED_CAST")
@@ -43,7 +43,7 @@ class DNSSettingsViewModel : IpnViewModel() {
           .combine(Notifier.prefs) { netmap, prefs -> Pair(netmap, prefs) }
           .stateIn(viewModelScope)
           .collect { (netmap, prefs) ->
-            Log.d("DNSSettingsViewModel", "prefs: CorpDNS=" + prefs?.CorpDNS.toString())
+            TSLog.d("DNSSettingsViewModel", "prefs: CorpDNS=" + prefs?.CorpDNS.toString())
             prefs?.let {
               if (it.CorpDNS) {
                 enablementState.set(DNSEnablementState.ENABLED)

--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/IpnViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/IpnViewModel.kt
@@ -3,7 +3,6 @@
 
 package com.tailscale.ipn.ui.viewModel
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.tailscale.ipn.UninitializedApp
@@ -16,6 +15,7 @@ import com.tailscale.ipn.ui.notifier.Notifier
 import com.tailscale.ipn.ui.util.AdvertisedRoutesHelper
 import com.tailscale.ipn.ui.util.LoadingIndicator
 import com.tailscale.ipn.ui.util.set
+import com.tailscale.ipn.util.TSLog
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -130,7 +130,7 @@ open class IpnViewModel : ViewModel() {
           }
           .collect { nodeState -> _nodeState.value = nodeState }
     }
-    Log.d(TAG, "Created")
+    TSLog.d(TAG, "Created")
   }
 
   // VPN Control
@@ -153,8 +153,8 @@ open class IpnViewModel : ViewModel() {
     val loginAction = {
       Client(viewModelScope).startLoginInteractive { result ->
         result
-            .onSuccess { Log.d(TAG, "Login started: $it") }
-            .onFailure { Log.e(TAG, "Error starting login: ${it.message}") }
+            .onSuccess { TSLog.d(TAG, "Login started: $it") }
+            .onFailure { TSLog.e(TAG, "Error starting login: ${it.message}") }
         completionHandler(result)
       }
     }
@@ -165,7 +165,7 @@ open class IpnViewModel : ViewModel() {
       Client(viewModelScope).editPrefs(Ipn.MaskedPrefs().apply { WantRunning = false }) { result ->
         result
             .onSuccess { loginAction() }
-            .onFailure { Log.e(TAG, "Error setting wantRunning to false: ${it.message}") }
+            .onFailure { TSLog.e(TAG, "Error setting wantRunning to false: ${it.message}") }
       }
     }
 
@@ -182,7 +182,7 @@ open class IpnViewModel : ViewModel() {
     if (mdmControlURL != null) {
       prefs = prefs ?: Ipn.MaskedPrefs()
       prefs.ControlURL = mdmControlURL
-      Log.d(TAG, "Overriding control URL with MDM value: $mdmControlURL")
+      TSLog.d(TAG, "Overriding control URL with MDM value: $mdmControlURL")
     }
 
     prefs?.let {
@@ -210,8 +210,8 @@ open class IpnViewModel : ViewModel() {
   fun logout(completionHandler: (Result<String>) -> Unit = {}) {
     Client(viewModelScope).logout { result ->
       result
-          .onSuccess { Log.d(TAG, "Logout started: $it") }
-          .onFailure { Log.e(TAG, "Error starting logout: ${it.message}") }
+          .onSuccess { TSLog.d(TAG, "Logout started: $it") }
+          .onFailure { TSLog.e(TAG, "Error starting logout: ${it.message}") }
       completionHandler(result)
     }
   }
@@ -221,14 +221,14 @@ open class IpnViewModel : ViewModel() {
   private fun loadUserProfiles() {
     Client(viewModelScope).profiles { result ->
       result.onSuccess(loginProfiles::set).onFailure {
-        Log.e(TAG, "Error loading profiles: ${it.message}")
+        TSLog.e(TAG, "Error loading profiles: ${it.message}")
       }
     }
 
     Client(viewModelScope).currentProfile { result ->
       result
           .onSuccess { loggedInUser.set(if (it.isEmpty()) null else it) }
-          .onFailure { Log.e(TAG, "Error loading current profile: ${it.message}") }
+          .onFailure { TSLog.e(TAG, "Error loading current profile: ${it.message}") }
     }
   }
 
@@ -242,7 +242,7 @@ open class IpnViewModel : ViewModel() {
     Client(viewModelScope).editPrefs(Ipn.MaskedPrefs().apply { WantRunning = false }) { result ->
       result
           .onSuccess { switchProfile() }
-          .onFailure { Log.e(TAG, "Error setting wantRunning to false: ${it.message}") }
+          .onFailure { TSLog.e(TAG, "Error setting wantRunning to false: ${it.message}") }
     }
   }
 
@@ -277,7 +277,7 @@ open class IpnViewModel : ViewModel() {
       Client(viewModelScope).setUseExitNode(true) { LoadingIndicator.stop() }
     } else {
       // This should not be possible.  In this state the button is hidden
-      Log.e(TAG, "No exit node to disable and no prior exit node to enable")
+      TSLog.e(TAG, "No exit node to disable and no prior exit node to enable")
     }
   }
 
@@ -292,7 +292,7 @@ open class IpnViewModel : ViewModel() {
       }
       Client(viewModelScope).editPrefs(newPrefs) { result ->
         LoadingIndicator.stop()
-        Log.d("RunExitNodeViewModel", "Edited prefs: $result")
+        TSLog.d("RunExitNodeViewModel", "Edited prefs: $result")
       }
     }
   }

--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/PingViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/PingViewModel.kt
@@ -5,7 +5,6 @@ package com.tailscale.ipn.ui.viewModel
 
 import android.content.Context
 import android.os.CountDownTimer
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -16,6 +15,7 @@ import com.tailscale.ipn.ui.model.Tailcfg
 import com.tailscale.ipn.ui.util.ConnectionMode
 import com.tailscale.ipn.ui.util.set
 import com.tailscale.ipn.ui.view.roundedString
+import com.tailscale.ipn.util.TSLog
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -39,7 +39,7 @@ class PingViewModel : ViewModel() {
         }
 
         override fun onFinish() {
-          Log.d(TAG, "Ping timer terminated")
+          TSLog.d(TAG, "Ping timer terminated")
         }
       }
 
@@ -94,7 +94,7 @@ class PingViewModel : ViewModel() {
         response.onFailure { error ->
           val context: Context = App.get().applicationContext
           val stringError = error.toString()
-          Log.d(TAG, "Ping request failed: $stringError")
+          TSLog.d(TAG, "Ping request failed: $stringError")
           if (stringError.contains("timeout")) {
             this.errorMessage.set(
                 context.getString(
@@ -125,7 +125,7 @@ class PingViewModel : ViewModel() {
           }
         }
       }
-      statusResult.onFailure { Log.d(TAG, "Failed to fetch status: $it") }
+      statusResult.onFailure { TSLog.d(TAG, "Failed to fetch status: $it") }
     }
   }
 }

--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/TaildropViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/TaildropViewModel.kt
@@ -4,7 +4,6 @@
 package com.tailscale.ipn.ui.viewModel
 
 import android.content.Context
-import android.util.Log
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.material3.MaterialTheme
@@ -26,6 +25,7 @@ import com.tailscale.ipn.ui.util.set
 import com.tailscale.ipn.ui.view.ActivityIndicator
 import com.tailscale.ipn.ui.view.CheckedIndicator
 import com.tailscale.ipn.ui.view.ErrorDialogType
+import com.tailscale.ipn.util.TSLog
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -144,7 +144,7 @@ class TaildropViewModel(
                 allSharablePeers.filter { !(it.Online ?: false) }.sortedBy { it.Name }
             myPeers.set(onlinePeers + offlinePeers)
           }
-          .onFailure { Log.e(TAG, "Error loading targets: ${it.message}") }
+          .onFailure { TSLog.e(TAG, "Error loading targets: ${it.message}") }
     }
   }
 

--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/VpnViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/VpnViewModel.kt
@@ -26,10 +26,13 @@ class VpnViewModelFactory(private val application: Application) : ViewModelProvi
 // application scoped because Tailscale might be toggled on and off outside of the activity
 // lifecycle.
 class VpnViewModel(application: Application) : AndroidViewModel(application) {
-  // Whether the VPN is prepared. This is set to true if the VPN application is already prepared, or if the user has previously consented to the VPN application. This is used to determine whether a VPN permission launcher needs to be shown. 
+  // Whether the VPN is prepared. This is set to true if the VPN application is already prepared, or
+  // if the user has previously consented to the VPN application. This is used to determine whether
+  // a VPN permission launcher needs to be shown.
   val _vpnPrepared = MutableStateFlow(false)
   val vpnPrepared: StateFlow<Boolean> = _vpnPrepared
-  // Whether a VPN interface has been established. This is set by net.updateTUN upon VpnServiceBuilder.establish, and consumed by UI to reflect VPN state. 
+  // Whether a VPN interface has been established. This is set by net.updateTUN upon
+  // VpnServiceBuilder.establish, and consumed by UI to reflect VPN state.
   val _vpnActive = MutableStateFlow(false)
   val vpnActive: StateFlow<Boolean> = _vpnActive
   val TAG = "VpnViewModel"

--- a/android/src/main/java/com/tailscale/ipn/util/TSLog.kt
+++ b/android/src/main/java/com/tailscale/ipn/util/TSLog.kt
@@ -1,0 +1,44 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+package com.tailscale.ipn.util
+
+import android.util.Log
+import libtailscale.Libtailscale
+
+object TSLog {
+  var libtailscaleWrapper = LibtailscaleWrapper()
+
+  fun d(tag: String?, message: String) {
+    Log.d(tag, message)
+    libtailscaleWrapper.sendLog(tag, message)
+  }
+
+  fun w(tag: String, message: String) {
+    Log.w(tag, message)
+    libtailscaleWrapper.sendLog(tag, message)
+  }
+
+  // Overloaded function without Throwable because Java does not support default parameters
+  @JvmStatic
+  fun e(tag: String?, message: String) {
+    Log.e(tag, message)
+    libtailscaleWrapper.sendLog(tag, message)
+  }
+
+  fun e(tag: String?, message: String, throwable: Throwable? = null) {
+    if (throwable == null) {
+      Log.e(tag, message)
+      libtailscaleWrapper.sendLog(tag, message)
+    } else {
+      Log.e(tag, message, throwable)
+      libtailscaleWrapper.sendLog(tag, "$message ${throwable?.localizedMessage}")
+    }
+  }
+
+  class LibtailscaleWrapper {
+    public fun sendLog(tag: String?, message: String) {
+      val logTag = tag ?: ""
+      Libtailscale.sendLog((logTag + ": " + message).toByteArray(Charsets.UTF_8))
+    }
+  }
+}

--- a/android/src/test/kotlin/com/tailcale/ipn/ui/util/TimeUtilTest.kt
+++ b/android/src/test/kotlin/com/tailcale/ipn/ui/util/TimeUtilTest.kt
@@ -1,60 +1,107 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
+
 package com.tailcale.ipn.ui.util
 
+
 import com.tailscale.ipn.ui.util.TimeUtil
+import com.tailscale.ipn.util.TSLog
+import com.tailscale.ipn.util.TSLog.LibtailscaleWrapper
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Before
 import org.junit.Test
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mockito.doNothing
+import org.mockito.Mockito.mock
 import java.time.Duration
+
 
 class TimeUtilTest {
 
-  @Test
-  fun durationInvalidMsUnits() {
-    val input = "5s10ms"
-    val actual = TimeUtil.duration(input)
-    assertNull("Should return null", actual)
-  }
 
-  @Test
-  fun durationInvalidUsUnits() {
-    val input = "5s10us"
-    val actual = TimeUtil.duration(input)
-    assertNull("Should return null", actual)
-  }
+ private lateinit var libtailscaleWrapperMock: LibtailscaleWrapper
+ private lateinit var originalWrapper: LibtailscaleWrapper
 
-  @Test
-  fun durationTestHappyPath() {
-    val input = arrayOf("1.0y1.0w1.0d1.0h1.0m1.0s", "1s", "1m", "1h", "1d", "1w", "1y")
-    val expectedSeconds =
-        arrayOf((31536000 + 604800 + 86400 + 3600 + 60 + 1), 1, 60, 3600, 86400, 604800, 31536000)
-    val expected = expectedSeconds.map { Duration.ofSeconds(it.toLong()) }
-    val actual = input.map { TimeUtil.duration(it) }
-    assertEquals("Incorrect conversion", expected, actual)
-  }
 
-  @Test
-  fun testBadDurationString() {
-    val input = "1..0y1.0w1.0d1.0h1.0m1.0s"
-    val actual = TimeUtil.duration(input)
-    assertNull("Should return null", actual)
-  }
+ @Before
+ fun setUp() {
+   libtailscaleWrapperMock = mock(LibtailscaleWrapper::class.java)
+   doNothing().`when`(libtailscaleWrapperMock).sendLog(anyString(), anyString())
 
-  @Test
-  fun testBadDInputString() {
-    val input = "1.0yy1.0w1.0d1.0h1.0m1.0s"
-    val actual = TimeUtil.duration(input)
-    assertNull("Should return null", actual)
-  }
 
-  @Test
-  fun testIgnoreFractionalSeconds() {
-    val input = "10.9s"
-    val expectedSeconds = 10
-    val expected = Duration.ofSeconds(expectedSeconds.toLong())
-    val actual = TimeUtil.duration(input)
-    assertEquals("Should return $expectedSeconds seconds", expected, actual)
-  }
+   // Store the original wrapper so we can reset it later
+   originalWrapper = TSLog.libtailscaleWrapper
+   // Inject mock into TSLog
+   TSLog.libtailscaleWrapper = libtailscaleWrapperMock
+ }
+
+
+ @After
+ fun tearDown() {
+   // Reset TSLog after each test to avoid side effects
+   TSLog.libtailscaleWrapper = originalWrapper
+ }
+
+
+ @Test
+ fun durationInvalidMsUnits() {
+   val input = "5s10ms"
+   val actual = TimeUtil.duration(input)
+   assertNull("Should return null", actual)
+ }
+
+
+ @Test
+ fun durationInvalidUsUnits() {
+   val input = "5s10us"
+   val actual = TimeUtil.duration(input)
+   assertNull("Should return null", actual)
+ }
+
+
+ @Test
+ fun durationTestHappyPath() {
+   val input = arrayOf("1.0y1.0w1.0d1.0h1.0m1.0s", "1s", "1m", "1h", "1d", "1w", "1y")
+   val expectedSeconds =
+       arrayOf((31536000 + 604800 + 86400 + 3600 + 60 + 1), 1, 60, 3600, 86400, 604800, 31536000)
+   val expected = expectedSeconds.map { Duration.ofSeconds(it.toLong()) }
+   val actual = input.map { TimeUtil.duration(it) }
+   assertEquals("Incorrect conversion", expected, actual)
+ }
+
+
+ @Test
+ fun testBadDurationString() {
+   val input = "1..0y1.0w1.0d1.0h1.0m1.0s"
+   val actual = TimeUtil.duration(input)
+   assertNull("Should return null", actual)
+ }
+
+
+ @Test
+ fun testBadDInputString() {
+   val libtailscaleWrapperMock = mock(LibtailscaleWrapper::class.java)
+   doNothing().`when`(libtailscaleWrapperMock).sendLog(anyString(), anyString())
+
+
+   val input = "1.0yy1.0w1.0d1.0h1.0m1.0s"
+   val actual = TimeUtil.duration(input)
+   assertNull("Should return null", actual)
+ }
+
+
+ @Test
+ fun testIgnoreFractionalSeconds() {
+   val input = "10.9s"
+   val expectedSeconds = 10
+   val expected = Duration.ofSeconds(expectedSeconds.toLong())
+   val actual = TimeUtil.duration(input)
+   assertEquals("Should return $expectedSeconds seconds", expected, actual)
+ }
 }
+
+
+

--- a/libtailscale/callbacks.go
+++ b/libtailscale/callbacks.go
@@ -20,6 +20,9 @@ var (
 
 	// onDNSConfigChanged is notified when the network changes and the DNS config needs to be updated. It receives the updated interface name.
 	onDNSConfigChanged = make(chan string, 1)
+
+	// onLog receives Android logs to be sent to the logger
+	onLog = make(chan string, 10)
 )
 
 // ifname is the interface name retrieved from LinkProperties on network change. An empty string is used if there is no network available.

--- a/libtailscale/interfaces.go
+++ b/libtailscale/interfaces.go
@@ -4,6 +4,8 @@
 package libtailscale
 
 import (
+	"log"
+
 	_ "golang.org/x/mobile/bind"
 )
 
@@ -168,4 +170,14 @@ func RequestVPN(service IPNService) {
 
 func ServiceDisconnect(service IPNService) {
 	onDisconnect <- service
+}
+
+func SendLog(logstr []byte) {
+	select {
+	case onLog <- string(logstr):
+		// Successfully sent log
+	default:
+		// Channel is full, log not sent
+		log.Printf("Log %v not sent", logstr) // missing argument in original code
+	}
 }

--- a/libtailscale/tailscale.go
+++ b/libtailscale/tailscale.go
@@ -134,4 +134,13 @@ func (b *backend) setupLogs(logDir string, logID logid.PrivateID, logf logger.Lo
 	if filchErr != nil {
 		log.Printf("SetupLogs: filch setup failed: %v", filchErr)
 	}
+
+	go func() {
+		for {
+			select {
+			case logstr := <-onLog:
+				b.logger.Logf(logstr)
+			}
+		}
+	}()
 }


### PR DESCRIPTION
ExtendedLog sends log messages to Android's logcat and Tailscale's logger Libtailscale wrapper is a Kotlin wrapper that allows us to get around the problems with mocking a native library

Fixes tailscale/corp#23191