### PR TITLE
Makefile: use "tailscale_go" build tag when using Tailscale's Go toolchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,7 @@ $(GOBIN)/gobind: go.mod go.sum
 
 $(LIBTAILSCALE): Makefile android/libs $(shell find libtailscale -name *.go) go.mod go.sum $(GOBIN)/gomobile
 	$(GOBIN)/gomobile bind -target android -androidapi 26 \
+		-tags "$$(./build-tags.sh)" \
 		-ldflags "$(FULL_LDFLAGS)" \
 		-o $@ ./libtailscale
 

--- a/build-tags.sh
+++ b/build-tags.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [[ -z "$TOOLCHAIN_DIR" ]]; then
+    # By default, if TOOLCHAIN_DIR is unset, we assume we're
+    # using the Tailscale Go toolchain (github.com/tailscale/go)
+    # at the revision specified by go.toolchain.rev. If so,
+    # we tell our caller to use the "tailscale_go" build tag.
+    echo "tailscale_go"
+else
+    # Otherwise, if TOOLCHAIN_DIR is specified, we assume
+    # we're F-Droid or something using a stock Go toolchain.
+    # That's fine. But we don't set the tailscale_go build tag.
+    # Return some no-op build tag that's non-empty for clarity
+    # when debugging.
+    echo "not_tailscale_go"
+fi


### PR DESCRIPTION
Updates tailscale/tailscale#13527
