### PR TITLE
android: set VPN status in service APIs

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/IPNService.kt
+++ b/android/src/main/java/com/tailscale/ipn/IPNService.kt
@@ -71,7 +71,7 @@ open class IPNService : VpnService(), libtailscale.IPNService {
       }
 
   override fun close() {
-    app.setWantRunning(false) { updateVpnStatus(false) }
+    app.setWantRunning(false) {}
     Notifier.setState(Ipn.State.Stopping)
     stopForeground(STOP_FOREGROUND_REMOVE)
     Libtailscale.serviceDisconnect(this)
@@ -79,11 +79,13 @@ open class IPNService : VpnService(), libtailscale.IPNService {
 
   override fun onDestroy() {
     close()
+    updateVpnStatus(false)
     super.onDestroy()
   }
 
   override fun onRevoke() {
     close()
+    updateVpnStatus(false)
     super.onRevoke()
   }
 


### PR DESCRIPTION
This is mainly a no-op; right now we are setting the VPN status when we successfully edit prefs with wantRunning=false, but the VPN status is separate from tailscaled status and reflects the status of the VPN interface. This change moves that status update into the Android Service APIs.

Updates tailscale/tailscale#12850
Updates tailscale/tailscale#12489