### PR TITLE
android: don't set vpnService to nil when state is Stopped

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/IPNService.kt
+++ b/android/src/main/java/com/tailscale/ipn/IPNService.kt
@@ -73,8 +73,12 @@ open class IPNService : VpnService(), libtailscale.IPNService {
   override fun close() {
     app.setWantRunning(false) { updateVpnStatus(false) }
     Notifier.setState(Ipn.State.Stopping)
-    stopForeground(STOP_FOREGROUND_REMOVE)
+    disconnectVPN()
     Libtailscale.serviceDisconnect(this)
+  }
+
+  override fun disconnectVPN(){
+    stopSelf()
   }
 
   override fun onDestroy() {

--- a/libtailscale/interfaces.go
+++ b/libtailscale/interfaces.go
@@ -80,6 +80,8 @@ type IPNService interface {
 
 	Close()
 
+	DisconnectVPN()
+
 	UpdateVpnStatus(bool)
 }
 

--- a/libtailscale/net.go
+++ b/libtailscale/net.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"net"
 	"net/netip"
-	"reflect"
 	"runtime/debug"
 	"strings"
 	"syscall"
@@ -125,12 +124,7 @@ var googleDNSServers = []netip.Addr{
 	netip.MustParseAddr("2001:4860:4860::8844"),
 }
 
-func (b *backend) updateTUN(service IPNService, rcfg *router.Config, dcfg *dns.OSConfig) error {
-	if reflect.DeepEqual(rcfg, b.lastCfg) && reflect.DeepEqual(dcfg, b.lastDNSCfg) {
-		b.logger.Logf("updateTUN: no change to Routes or DNS, ignore")
-		return nil
-	}
-
+func (b *backend) updateTUN(rcfg *router.Config, dcfg *dns.OSConfig) error {
 	b.logger.Logf("updateTUN: changed")
 	defer b.logger.Logf("updateTUN: finished")
 
@@ -147,7 +141,6 @@ func (b *backend) updateTUN(service IPNService, rcfg *router.Config, dcfg *dns.O
 	if len(rcfg.LocalAddrs) == 0 {
 		return nil
 	}
-	vpnService.service = service
 	builder := vpnService.service.NewBuilder()
 	b.logger.Logf("updateTUN: got new builder")
 
@@ -258,7 +251,6 @@ func closeFileDescriptor() error {
 func (b *backend) CloseTUNs() {
 	b.lastCfg = nil
 	b.devices.Shutdown()
-	vpnService.service = nil
 }
 
 // ifname is the interface name retrieved from LinkProperties on network change. If a network is lost, an empty string is passed in.


### PR DESCRIPTION
We are currently setting vpnService.service to nil: -any time there’s an error with updateTUN
-when we exit out of runBackend
-if the config is the default config (aka when the ipn state is Stopped)

When it gets set to nil, we don’t handle state or config updates by calling updateTUN until after startVPN is called again. The second case never happens because there’s no condition to break out of the loop in runBackend and ctx is uncancelable per the doc for context.Background() In the third case, we should not establish the VPN; the state is already in the correct Stopped state, but there’s no need to set the service to nil and prevent updateTUN from being called. The quick settings tile bug is caused by this third case, where because the saved prefs starts the app up in the Stopped state, the config is set to the default config, and the service is set to nil, and we can't updateTUN until there’s another startVPN call.

This PR:
-cleans up the updateTUN error handling to be more consistent -removes the IPNService parameter from updateTUN so that vpnService.service is not set to nil in the third case

Fixes tailscale/tailscale#12489