### PR TITLE
android: don't show permissions for TV

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/ui/view/SettingsView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/SettingsView.kt
@@ -39,6 +39,7 @@ import com.tailscale.ipn.ui.viewModel.SettingsNav
 import com.tailscale.ipn.ui.viewModel.SettingsViewModel
 import com.tailscale.ipn.ui.viewModel.VpnViewModel
 import com.tailscale.ipn.ui.notifier.Notifier
+import com.tailscale.ipn.ui.util.AndroidTVUtil
 import com.tailscale.ipn.ui.util.AppVersion
 
 @Composable
@@ -96,9 +97,10 @@ fun SettingsView(settingsNav: SettingsNav, viewModel: SettingsViewModel = viewMo
                     },
                 onClick = settingsNav.onNavigateToTailnetLock)
           }
-
-          Lists.ItemDivider()
-          Setting.Text(R.string.permissions, onClick = settingsNav.onNavigateToPermissions)
+          if (!AndroidTVUtil.isAndroidTV()){
+            Lists.ItemDivider()
+            Setting.Text(R.string.permissions, onClick = settingsNav.onNavigateToPermissions)
+          }
 
           managedByOrganization.value?.let {
             Lists.ItemDivider()


### PR DESCRIPTION
Android TV has limited support for notifications compared to mobile - notifications are not show in the system UI to provide a leanback experience. Remove 'Permissions' from Settings menu.

Fixes tailscale/corp/#21034