### PR TITLE
android: use a coroutine for loadfiles

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/ShareActivity.kt
+++ b/android/src/main/java/com/tailscale/ipn/ShareActivity.kt
@@ -14,14 +14,18 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.lifecycleScope
 import com.tailscale.ipn.ui.model.Ipn
 import com.tailscale.ipn.ui.theme.AppTheme
 import com.tailscale.ipn.ui.util.set
 import com.tailscale.ipn.ui.util.universalFit
 import com.tailscale.ipn.ui.view.TaildropView
 import com.tailscale.ipn.util.TSLog
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlin.random.Random
 
 // ShareActivity is the entry point for Taildrop share intents
@@ -47,7 +51,7 @@ class ShareActivity : ComponentActivity() {
     super.onStart()
     // Ensure our app instance is initialized
     App.get()
-    loadFiles()
+    lifecycleScope.launch { withContext(Dispatchers.IO) { loadFiles() } }
   }
 
   override fun onNewIntent(intent: Intent) {


### PR DESCRIPTION
contentResolver.query is attempting to perform a network query on the main thread. Move this to a coroutine to prevent blocking.

Fixes tailscale/corp#24293