### PR TITLE
Makefile: fix clean action dependencies

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
     branches:
-      - '*'
+      - "*"
 
 jobs:
   build:
@@ -15,20 +15,23 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
 
     steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+      - name: Switch to Java 17 # Note: 17 is pre-installed on ubuntu-latest
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "17"
 
-    - name: Check out code
-      uses: actions/checkout@v3
-    - uses: actions/setup-go@v5
-      with: 
-        go-version-file: 'go.mod'
-    - name: Switch to Java 17 # Note: 17 is pre-installed on ubuntu-latest
-      uses: actions/setup-java@v3
-      with:
-        distribution: 'temurin'
-        java-version: '17'
+      # Clean should essentially be a no-op, but make sure that it works.
+      - name: Clean
+        run: make clean
 
-    - name: Build APKs
-      run: make tailscale-debug.apk
+      - name: Build APKs
+        run: make tailscale-debug.apk
 
-    - name: Run tests
-      run: make test
+      - name: Run tests
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -299,7 +299,7 @@ docker-remove-shell-image: ## Removes all docker shell image
 	docker rmi --force tailscale-android-shell-amd64
 
 .PHONY: clean
-clean: clean-tailscale.version ## Remove build artifacts.  Does not purge docker build envs.  Use dockerRemoveEnv for that.
+clean: ## Remove build artifacts.  Does not purge docker build envs.  Use dockerRemoveEnv for that.
 	@echo "Cleaning up old build artifacts"
 	-rm -rf android/build $(DEBUG_APK) $(RELEASE_AAB) $(RELEASE_TV_AAB) $(LIBTAILSCALE) android/libs *.apk *.aab
 	@echo "Cleaning cached toolchain"


### PR DESCRIPTION
The explicit target was removed during patch production, but the dependency wasn't removed from the clean action.

Updates #546
Updates tailscale/tailscale#13850