### PR TITLE
android: use a coroutine for loadfiles

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,7 +38,7 @@ android {
         minSdkVersion 26
         targetSdkVersion 34
         versionCode 310
-        versionName "1.76.2-t088d78591-gfafffd2aeba"
+        versionName "1.77.75-td4222fae9-gc543614f10a"
 
         // This setting, which defaults to 'true', will cause Tailscale to fall
         // back to the Google DNS servers if it cannot determine what the

--- a/android/src/main/java/com/tailscale/ipn/ShareActivity.kt
+++ b/android/src/main/java/com/tailscale/ipn/ShareActivity.kt
@@ -14,14 +14,18 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.lifecycleScope
 import com.tailscale.ipn.ui.model.Ipn
 import com.tailscale.ipn.ui.theme.AppTheme
 import com.tailscale.ipn.ui.util.set
 import com.tailscale.ipn.ui.util.universalFit
 import com.tailscale.ipn.ui.view.TaildropView
 import com.tailscale.ipn.util.TSLog
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlin.random.Random
 
 // ShareActivity is the entry point for Taildrop share intents
@@ -47,7 +51,7 @@ class ShareActivity : ComponentActivity() {
     super.onStart()
     // Ensure our app instance is initialized
     App.get()
-    loadFiles()
+    lifecycleScope.launch { withContext(Dispatchers.IO) { loadFiles() } }
   }
 
   override fun onNewIntent(intent: Intent) {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/tailscale/wireguard-go v0.0.0-20240905161824-799c1978fafc
 	golang.org/x/mobile v0.0.0-20240806205939-81131f6468ab
 	inet.af/netaddr v0.0.0-20220617031823-097006376321
-	tailscale.com v1.76.2-0.20241017163834-088d78591c81
+	tailscale.com v1.75.0-pre.0.20241103175838-d4222fae95c0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -256,11 +256,5 @@ inet.af/netaddr v0.0.0-20220617031823-097006376321 h1:B4dC8ySKTQXasnjDTMsoCMf1sQ
 inet.af/netaddr v0.0.0-20220617031823-097006376321/go.mod h1:OIezDfdzOgFhuw4HuWapWq2e9l0H9tK4F1j+ETRtF3k=
 software.sslmate.com/src/go-pkcs12 v0.4.0 h1:H2g08FrTvSFKUj+D309j1DPfk5APnIdAQAB8aEykJ5k=
 software.sslmate.com/src/go-pkcs12 v0.4.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=
-tailscale.com v1.75.0-pre.0.20241009122300-f6d4d03355eb h1:Sj+gV1UTEu0C72EI3rSGoSJPE/i+qTKgnUWgtb611y8=
-tailscale.com v1.75.0-pre.0.20241009122300-f6d4d03355eb/go.mod h1:myCwmhYBvMCF/5OgBYuIW42zscuEo30bAml7wABVZLk=
-tailscale.com v1.76.0 h1:6fS66odV7LySVzS2ZmJebWETeS26grV8iaKZfWgXaPA=
-tailscale.com v1.76.0/go.mod h1:myCwmhYBvMCF/5OgBYuIW42zscuEo30bAml7wABVZLk=
-tailscale.com v1.76.1-0.20241015182059-24929f6b6111 h1:EfNlWDTa4Togeo0XIIvmn41A/8hfD4vEBxw3PDeT88o=
-tailscale.com v1.76.1-0.20241015182059-24929f6b6111/go.mod h1:myCwmhYBvMCF/5OgBYuIW42zscuEo30bAml7wABVZLk=
-tailscale.com v1.76.2-0.20241017163834-088d78591c81 h1:AI7VyXSymn58THiEAYPhcze6LpiqzjY9WFdT9PmJXtU=
-tailscale.com v1.76.2-0.20241017163834-088d78591c81/go.mod h1:myCwmhYBvMCF/5OgBYuIW42zscuEo30bAml7wABVZLk=
+tailscale.com v1.75.0-pre.0.20241103175838-d4222fae95c0 h1:WildwJotNyCEDvdjPZVmR1RHuX09jF31LrAvL0IpILE=
+tailscale.com v1.75.0-pre.0.20241103175838-d4222fae95c0/go.mod h1:myCwmhYBvMCF/5OgBYuIW42zscuEo30bAml7wABVZLk=


### PR DESCRIPTION
contentResolver.query is attempting to perform a network query on the main thread. Move this to a coroutine to prevent blocking.

Fixes tailscale/corp#24293

Signed-off-by: kari-ts <kari@tailscale.com>
(cherry picked from commit 0b01eb1bb34240ff1a559d3a19a0b5a98fe35b49)