### PR TITLE
android: lazily init app in Client

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/App.kt
+++ b/android/src/main/java/com/tailscale/ipn/App.kt
@@ -90,6 +90,13 @@ class App : UninitializedApp(), libtailscale.AppContext, ViewModelStoreOwner {
     Log.d(s, s1)
   }
 
+  fun getLibtailscaleApp(): libtailscale.Application {
+    if (!isInitialized) {
+      initOnce() // Calls the synchronized initialization logic
+    }
+    return app
+  }
+
   override fun onCreate() {
     super.onCreate()
     createNotificationChannel(
@@ -119,15 +126,19 @@ class App : UninitializedApp(), libtailscale.AppContext, ViewModelStoreOwner {
     viewModelStore.clear()
   }
 
-  private var isInitialized = false
+  @Volatile private var isInitialized = false
 
   @Synchronized
   private fun initOnce() {
     if (isInitialized) {
       return
     }
-    isInitialized = true
 
+    initializeApp()
+    isInitialized = true
+  }
+
+  private fun initializeApp() {
     val dataDir = this.filesDir.absolutePath
 
     // Set this to enable direct mode for taildrop whereby downloads will be saved directly

--- a/android/src/main/java/com/tailscale/ipn/ui/localapi/Client.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/localapi/Client.kt
@@ -13,6 +13,7 @@ import com.tailscale.ipn.ui.model.StableNodeID
 import com.tailscale.ipn.ui.model.Tailcfg
 import com.tailscale.ipn.ui.util.InputStreamAdapter
 import com.tailscale.ipn.util.TSLog
+import com.tailscale.ipn.App
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -66,6 +67,11 @@ typealias PingResultHandler = (Result<IpnState.PingResult>) -> Unit
  */
 class Client(private val scope: CoroutineScope) {
   private val TAG = Client::class.simpleName
+
+  // Access libtailscale.Application lazily
+  private val app: libtailscale.Application by lazy {
+    App.get().getLibtailscaleApp()
+}
 
   fun start(options: Ipn.Options, responseHandler: (Result<Unit>) -> Unit) {
     val body = Json.encodeToString(options).toByteArray()


### PR DESCRIPTION
-Lazily init app in Client to ensure that we aren't trying to make any local API calls before app has been initialized. 
-Add @Volatile to ensure that isInitialized is always visible across threads and uses the updated value

Updates tailscale/tailscale#14125