### PR TITLE
android: bump OSS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/tailscale/wireguard-go v0.0.0-20241113014420-4e883d38c8d3
 	golang.org/x/mobile v0.0.0-20240806205939-81131f6468ab
 	inet.af/netaddr v0.0.0-20220617031823-097006376321
-	tailscale.com v1.75.0-pre.0.20241119130719-00517c818956
+	tailscale.com v1.77.0-pre.0.20241119172557-bb3d0cae5f76
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -256,5 +256,5 @@ inet.af/netaddr v0.0.0-20220617031823-097006376321 h1:B4dC8ySKTQXasnjDTMsoCMf1sQ
 inet.af/netaddr v0.0.0-20220617031823-097006376321/go.mod h1:OIezDfdzOgFhuw4HuWapWq2e9l0H9tK4F1j+ETRtF3k=
 software.sslmate.com/src/go-pkcs12 v0.4.0 h1:H2g08FrTvSFKUj+D309j1DPfk5APnIdAQAB8aEykJ5k=
 software.sslmate.com/src/go-pkcs12 v0.4.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=
-tailscale.com v1.75.0-pre.0.20241119130719-00517c818956 h1:921sHsecXKeHcJXgUer07rl8WAV+u4nmLghUbQ6zeLk=
-tailscale.com v1.75.0-pre.0.20241119130719-00517c818956/go.mod h1:OQHJodEdJx4e8lKkSpYmK2H/B1D/VN0EU7g9imiGj2k=
+tailscale.com v1.77.0-pre.0.20241119172557-bb3d0cae5f76 h1:0yp6sjCjsUUcBmLDor8jpVevFtvH31YNqkKeUvNX3b0=
+tailscale.com v1.77.0-pre.0.20241119172557-bb3d0cae5f76/go.mod h1:OQHJodEdJx4e8lKkSpYmK2H/B1D/VN0EU7g9imiGj2k=


### PR DESCRIPTION
OSS and Version updated to 1.77.113-t00517c818-ge95b7b7f6

Rebumping after fixing OSS -pre tags.