### PR TITLE
android: synchronize Notifier app initialization

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/ui/notifier/Notifier.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/notifier/Notifier.kt
@@ -53,11 +53,13 @@ object Notifier {
   private lateinit var app: libtailscale.Application
   private var manager: libtailscale.NotificationManager? = null
 
+  @Synchronized
   @JvmStatic
   fun setApp(newApp: libtailscale.Application) {
     app = newApp
   }
 
+  @Synchronized
   @OptIn(ExperimentalSerializationApi::class)
   fun start(scope: CoroutineScope) {
     TSLog.d(TAG, "Starting Notifier")


### PR DESCRIPTION
@Synchronize Notifier.setApp and Notifier.start to make sure that app isn't being accessed while being set.

Updates tailscale/corp#24694