### PR TITLE
android: exclude Adaptive Connectivity Services

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/App.kt
+++ b/android/src/main/java/com/tailscale/ipn/App.kt
@@ -583,5 +583,7 @@ open class UninitializedApp : Application() {
           "com.vna.service.vvm",
           "com.dish.vvm",
           "com.comcast.modesto.vvm.client",
+          // Android Connectivity Service https://github.com/tailscale/tailscale/issues/14128
+          "com.google.android.apps.scone",
       )
 }


### PR DESCRIPTION
Default to excluding Adaptive Connectivity Services to fix issue where it is erroneously classifying wifi as broken

Fixes tailscale/tailscale#14128