### PR TITLE
mdm: update MDMSettings (and syspolicy) when application restrictions change

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/mdm/MDMSettingsChangedReceiver.kt
+++ b/android/src/main/java/com/tailscale/ipn/mdm/MDMSettingsChangedReceiver.kt
@@ -1,0 +1,21 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package com.tailscale.ipn.mdm
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.RestrictionsManager
+import com.tailscale.ipn.App
+import com.tailscale.ipn.util.TSLog
+
+class MDMSettingsChangedReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context?, intent: Intent?) {
+        if (intent?.action == android.content.Intent.ACTION_APPLICATION_RESTRICTIONS_CHANGED) {
+            TSLog.d("syspolicy", "MDM settings changed")
+            val restrictionsManager = context?.getSystemService(Context.RESTRICTIONS_SERVICE) as RestrictionsManager
+            MDMSettings.update(App.get(), restrictionsManager)
+        }
+    }
+}


### PR DESCRIPTION
In this PR, we update the Android app to register a broadcast receiver that listens for `android.content.Intent.ACTION_APPLICATION_RESTRICTIONS_CHANGED` and updates `MDMSettings` whenever a change occurs. This, in turn, notifies the Go backend and causes it to reload syspolicy, ensuring it reflects the updated MDM settings.

Updates tailscale/tailscale#12687