### PR TITLE
HealthNotifier: prevent and drop all warnings in the Stopped state

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/App.kt
+++ b/android/src/main/java/com/tailscale/ipn/App.kt
@@ -158,7 +158,7 @@ class App : UninitializedApp(), libtailscale.AppContext, ViewModelStoreOwner {
     Request.setApp(app)
     Notifier.setApp(app)
     Notifier.start(applicationScope)
-    healthNotifier = HealthNotifier(Notifier.health, applicationScope)
+    healthNotifier = HealthNotifier(Notifier.health, Notifier.state, applicationScope)
     connectivityManager = this.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
     NetworkChangeCallback.monitorDnsChanges(connectivityManager, dns)
     initViewModels()


### PR DESCRIPTION
Updates tailscale/tailscale#12960

When the client is Stopped after running, a false positive DERP warning was getting presented. This was not happening on Apple platforms because we never leave the client in a Stopped state, the extension instantly terminates. Since that's not the case on Android, this PR ensures that:

- we do not present any warnings when the client is Stopped (nothing should be broken when nothing is running)
- if we enter the Stopped state, any pre-existing warnings generated while the client was running are dropped