### PR TITLE
android: specify whether or not receivers are exported

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -99,6 +99,14 @@
             </intent-filter>
         </receiver>
 
+        <receiver
+            android:name=".MDMSettingsChangedReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.APPLICATION_RESTRICTIONS_CHANGED" />
+            </intent-filter>
+        </receiver>
+
         <service
             android:name=".IPNService"
             android:exported="false"

--- a/android/src/main/java/com/tailscale/ipn/App.kt
+++ b/android/src/main/java/com/tailscale/ipn/App.kt
@@ -461,7 +461,7 @@ open class UninitializedApp : Application() {
 
     // Register the receiver before stopping VPN
     val intentFilter = IntentFilter(IPNService.ACTION_STOP_VPN)
-    this.registerReceiver(stopReceiver, intentFilter)
+    this.registerReceiver(stopReceiver, intentFilter, Context.RECEIVER_NOT_EXPORTED)
 
     stopVPN()
   }

--- a/android/src/main/java/com/tailscale/ipn/mdm/MDMSettingsChangedReceiver.kt
+++ b/android/src/main/java/com/tailscale/ipn/mdm/MDMSettingsChangedReceiver.kt
@@ -12,7 +12,7 @@ import com.tailscale.ipn.util.TSLog
 
 class MDMSettingsChangedReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent?) {
-        if (intent?.action == android.content.Intent.ACTION_APPLICATION_RESTRICTIONS_CHANGED) {
+        if (intent?.action == Intent.ACTION_APPLICATION_RESTRICTIONS_CHANGED) {
             TSLog.d("syspolicy", "MDM settings changed")
             val restrictionsManager = context?.getSystemService(Context.RESTRICTIONS_SERVICE) as RestrictionsManager
             MDMSettings.update(App.get(), restrictionsManager)


### PR DESCRIPTION
Per https://developer.android.com/about/versions/14/behavior-changes-14#runtime-receivers-exported, we need to register all receivers.

Fixes tailscale/corp#25021