### PR TITLE
android: hide allow LAN access if feature not enabled

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/ui/view/ExitNodePicker.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/ExitNodePicker.kt
@@ -36,13 +36,14 @@ import com.tailscale.ipn.ui.viewModel.ExitNodePickerViewModel
 import com.tailscale.ipn.ui.viewModel.ExitNodePickerViewModelFactory
 import com.tailscale.ipn.ui.viewModel.selected
 import kotlinx.coroutines.flow.MutableStateFlow
+import android.os.Build
 
 @Composable
 fun ExitNodePicker(
     nav: ExitNodePickerNav,
     model: ExitNodePickerViewModel = viewModel(factory = ExitNodePickerViewModelFactory(nav))
 ) {
-  LoadingIndicator.Wrap {
+  LoadingIndicator.Wrap { 
     Scaffold(topBar = { Header(R.string.choose_exit_node, onBack = nav.onNavigateBackHome) }) {
         innerPadding ->
       val tailnetExitNodes by model.tailnetExitNodes.collectAsState()
@@ -99,7 +100,8 @@ fun ExitNodePicker(
           }
         }
 
-        if (!allowLanAccessMDMDisposition.value.hiddenFromUser) {
+        // https://developer.android.com/reference/android/net/VpnService.Builder#excludeRoute(android.net.IpPrefix) - excludeRoute is only supported in API 33+, so don't show the option if allow LAN access is not enabled.
+        if (!allowLanAccessMDMDisposition.value.hiddenFromUser && Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
           item(key = "allowLANAccess") {
             Lists.SectionDivider()
 


### PR DESCRIPTION
excludeRoute is only supported on API 33+, so we are not supporting allow LAN access for older versions. To avoid confusion, don't show the option if the feature is not enabled.

Updates tailscale/corp#25083