### PR TITLE
android: synchronize ipn state and UI

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/ui/view/MainView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/MainView.kt
@@ -145,13 +145,12 @@ fun MainView(
                 leadingContent = {
                   if (!hideHeader) {
                     TintedSwitch(
-                        onCheckedChange = {
-                          if (!disableToggle.value) {
-                            viewModel.toggleVpn()
-                          }
-                        },
-                        enabled = !disableToggle.value,
-                        checked = isOn)
+                        checked = isOn,
+                        enabled =
+                            !disableToggle.value &&
+                                !viewModel.isToggleInProgress
+                                    .value, // Disable switch if toggle is in progress
+                        onCheckedChange = { desiredState -> viewModel.toggleVpn(desiredState) })
                   }
                 },
                 headlineContent = {
@@ -228,7 +227,7 @@ fun MainView(
                     // action (eg, if the user connected to another VPN).
                     state != Ipn.State.Stopping,
                     user,
-                    { viewModel.toggleVpn() },
+                    { viewModel.toggleVpn(desiredState = !isOn) },
                     { viewModel.login() },
                     loginAtUrl,
                     netmap?.SelfNode,


### PR DESCRIPTION
Pass in intended state to toggleVpn and keep track of progress to avoid redundant updates and ensure that the action taken reflects the user's intent. This fixes a possible recomposition loop caused by the ipn state and the vpn toggle state getting out of sync.

Updates tailscale/tailscale#14125