### PR TITLE
github/workflows/{android,go_mod_tidy}: run on all PRs and on pushes to {main,release-branch/*}

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches:
       - main
+      - "release-branch/*"
   pull_request:
-    branches:
-      - "*"
+    # all PRs on all branches
 
 jobs:
   build:

--- a/.github/workflows/go_mod_tidy.yml
+++ b/.github/workflows/go_mod_tidy.yml
@@ -6,8 +6,7 @@ on:
       - main
       - "release-branch/*"
   pull_request:
-    branches:
-      - "*"
+    # all PRs on all branches
 
 concurrency:
   group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
Previously, using `*` in branch filters prevented PR CI actions from running on prefixed branches such as `release-branch/*` because `*` only matches characters except for forward slashes. In this PR, we remove the branch filter to ensure that Android builds and go mod tidy checks are executed on all PRs, regardless of the target branch. Additionally, these checks will now run on pushes to `release-branch/*`.

Fixes tailscale/corp#25313