### PR TITLE
android: mark Quick Settings tile as toggleable

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -125,6 +125,9 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.TOGGLEABLE_TILE"
+                android:value="true" />
         </service>
 
         <meta-data


### PR DESCRIPTION
Mark the Quick Settings tile as toggleable.

The primary function of the Quick Settings tile is to turn on or of the VPN connection so it should be marked as toggleable as per the Android guidelines: https://developer.android.com/develop/ui/views/quicksettings-tiles#mark-tile

This also removes the little chevron on the tile which should only be shown on tiles that open a dialog or activity.