### PR TITLE
mdm: define Hostname syspolicy on Android

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/mdm/MDMSettings.kt
+++ b/android/src/main/java/com/tailscale/ipn/mdm/MDMSettings.kt
@@ -94,6 +94,9 @@ object MDMSettings {
   // Handled on the backend
   val authKey = StringMDMSetting("AuthKey", "Auth Key for login")
 
+  // Overrides the value provided by os.Hostname() in Go
+  val hostname = StringMDMSetting("Hostname", "Device Hostname")
+
   val allSettings by lazy {
     MDMSettings::class
         .declaredMemberProperties

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -319,5 +319,7 @@
     <string name="run_as_subnet_router">Run as subnet router</string>
     <string name="use_tailscale_subnets_subtitle">Route traffic according to your network\'s rules. Some networks require this to access IP addresses that don\'t start with 100.x.y.z.</string>
     <string name="subnet_routing">Subnet routing</string>
+    <string name="specifies_a_device_name_to_be_used_instead_of_the_automatic_default">Specifies a device name to be used instead of the automatic default.</string>
+    <string name="hostname">Hostname</string>
 
 </resources>

--- a/android/src/main/res/xml/app_restrictions.xml
+++ b/android/src/main/res/xml/app_restrictions.xml
@@ -128,4 +128,10 @@
         android:key="AuthKey"
         android:restrictionType="string"
         android:title="@string/auth_key" />
+
+    <restriction
+        android:description="@string/specifies_a_device_name_to_be_used_instead_of_the_automatic_default"
+        android:key="Hostname"
+        android:restrictionType="string"
+        android:title="@string/hostname" />
 </restrictions>


### PR DESCRIPTION
Updates tailscale/corp#25936

Adds a definition for the Hostname syspolicy which we are adding in OSS: https://github.com/tailscale/tailscale/pull/14676

Also adds it to the app_restrictions.xml file so that MDM solutions can pick it up.