### PR TITLE
android: bump OSS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/tailscale/wireguard-go v0.0.0-20250107165329-0b8b35511f19
 	golang.org/x/mobile v0.0.0-20240806205939-81131f6468ab
 	inet.af/netaddr v0.0.0-20220617031823-097006376321
-	tailscale.com v1.79.0-pre.0.20250117225247-c79b736a856b
+	tailscale.com v1.79.0-pre.0.20250124141744-05afa31df3e3
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -248,5 +248,5 @@ inet.af/netaddr v0.0.0-20220617031823-097006376321 h1:B4dC8ySKTQXasnjDTMsoCMf1sQ
 inet.af/netaddr v0.0.0-20220617031823-097006376321/go.mod h1:OIezDfdzOgFhuw4HuWapWq2e9l0H9tK4F1j+ETRtF3k=
 software.sslmate.com/src/go-pkcs12 v0.4.0 h1:H2g08FrTvSFKUj+D309j1DPfk5APnIdAQAB8aEykJ5k=
 software.sslmate.com/src/go-pkcs12 v0.4.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=
-tailscale.com v1.79.0-pre.0.20250117225247-c79b736a856b h1:XnHYoy6T7AaPFFWnSRCg7563sSmEOsknmzxwcHMJ1KE=
-tailscale.com v1.79.0-pre.0.20250117225247-c79b736a856b/go.mod h1:ABzV+1HvaG+72MdrrsXBIgj1/+aJJHlxHzBQFTNSfn8=
+tailscale.com v1.79.0-pre.0.20250124141744-05afa31df3e3 h1:Xqw1dzBACCVdiTiCezV61Ix/JCqPWnN6555TbpueXYM=
+tailscale.com v1.79.0-pre.0.20250124141744-05afa31df3e3/go.mod h1:LiqqX5JzzJTuE0VXqn28DcEX1DStsTcVGGvrbaYFu+4=

--- a/libtailscale/backend.go
+++ b/libtailscale/backend.go
@@ -17,6 +17,7 @@ import (
 	"sync/atomic"
 
 	"tailscale.com/drive/driveimpl"
+	_ "tailscale.com/feature/condregister"
 	"tailscale.com/hostinfo"
 	"tailscale.com/ipn"
 	"tailscale.com/ipn/ipnlocal"


### PR DESCRIPTION
OSS and Version updated to 1.79.134-tc79b736a8-g0f6059dfc

Updates tailscale/corp#26049