### PR TITLE
android/tv: remove avatar padding in userView

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/ui/view/Avatar.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/Avatar.kt
@@ -51,7 +51,7 @@ fun Avatar(
       modifier =
           Modifier.conditional(AndroidTVUtil.isAndroidTV(), { padding(4.dp) })
               .conditional(
-                  AndroidTVUtil.isAndroidTV(),
+                  AndroidTVUtil.isAndroidTV() && isFocusable,
                   {
                     size((size * 1.5f).dp) // Focusable area is larger than the avatar
                   })

--- a/android/src/main/java/com/tailscale/ipn/ui/view/UserView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/UserView.kt
@@ -52,7 +52,7 @@ fun UserView(
       ListItem(
           modifier = modifier,
           colors = colors,
-          leadingContent = { Avatar(profile = profile, size = 36) },
+          leadingContent = { Avatar(profile = profile, size = 36, isFocusable = false) },
           headlineContent = {
             AutoResizingText(
                 text = profile.UserProfile.LoginName,


### PR DESCRIPTION
updates tailscale/corp#26199

Removes the avatar padding when the avatar is not focusable on AndroidTV.

![Screenshot 2025-01-29 at 1 52 19 PM](https://github.com/user-attachments/assets/f02883e5-70b2-4338-9594-37ec10fb9edd)
