### PR TITLE
android: check back stack before popping back

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/MainActivity.kt
+++ b/android/src/main/java/com/tailscale/ipn/MainActivity.kt
@@ -341,11 +341,23 @@ class MainActivity : ComponentActivity() {
   override fun onNewIntent(intent: Intent) {
     super.onNewIntent(intent)
     if (intent.getBooleanExtra(START_AT_ROOT, false)) {
-      if (this::navController.isInitialized) {
-        navController.popBackStack(route = "main", inclusive = false)
-      }
+        if (this::navController.isInitialized) {
+            val previousEntry = navController.previousBackStackEntry
+            TSLog.d("MainActivity", "onNewIntent: previousBackStackEntry = $previousEntry")
+
+            if (previousEntry != null) {
+                navController.popBackStack(route = "main", inclusive = false)
+            } else {
+                TSLog.e("MainActivity", "onNewIntent: No previous back stack entry, navigating directly to 'main'")
+                navController.navigate("main") {
+                    popUpTo("main") { inclusive = true }
+                }
+            }
+        }
     }
-  }
+}
+
+
 
   private fun login(urlString: String) {
     // Launch coroutine to listen for state changes. When the user completes login, relaunch


### PR DESCRIPTION
A possible cause for an IndexOutOfBounds exception is that when the intent is delivered, the back stack doesn't have enough entries for the operation. Condition popping back on if there is more than one entry in the back stack; otherwise, navigate directly to main to reset the back stack.

Updates tailscale/tailscale#15188