### PR TITLE
android: only use new search for API 33+

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/ui/view/MainView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/MainView.kt
@@ -540,13 +540,15 @@ fun PeerList(
   var isListFocussed by remember { mutableStateOf(false) }
   val expandedPeer = viewModel.expandedMenuPeer.collectAsState()
   val localClipboardManager = LocalClipboardManager.current
-  val enableSearch = !isAndroidTV()
+  // Restrict search to devices running API 33+ (see https://github.com/tailscale/corp/issues/27375)
+  val enableSearch = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+
 
   Column(modifier = Modifier.fillMaxSize()) {
-    if (FeatureFlags.isEnabled("enable_new_search")) {
+    if (enableSearch && FeatureFlags.isEnabled("enable_new_search")) {
       Search(onSearchBarClick)
     } else {
-      if (enableSearch) {
+      if (!isAndroidTV()) {
         Box(
             modifier =
                 Modifier.fillMaxWidth().background(color = MaterialTheme.colorScheme.surface)) {


### PR DESCRIPTION
disable search for Android TV running < API 33

Updates tailscale/corp#27375