### PR TITLE
android: add logging to track VPN interface creation

### DIFF
--- a/libtailscale/backend.go
+++ b/libtailscale/backend.go
@@ -225,6 +225,8 @@ func (a *App) runBackend(ctx context.Context) error {
 				if err := b.updateTUN(cfg.rcfg, cfg.dcfg); err != nil {
 					a.closeVpnService(err, b)
 				}
+			} else {
+				b.logger.Logf("Update TUN not called")
 			}
 		case s := <-onDisconnect:
 			b.CloseTUNs()

--- a/libtailscale/interfaces.go
+++ b/libtailscale/interfaces.go
@@ -166,6 +166,7 @@ type InputStream interface {
 // of various state changes.
 
 func RequestVPN(service IPNService) {
+	log.Printf("VPN requested")
 	onVPNRequested <- service
 }
 

--- a/libtailscale/net.go
+++ b/libtailscale/net.go
@@ -207,6 +207,7 @@ func (b *backend) updateTUN(rcfg *router.Config, dcfg *dns.OSConfig) error {
 	b.logger.Logf("updateTUN: established VPN")
 
 	if parcelFD == nil {
+		b.logger.Logf("updateTUN: could not establish VPN because builder.Establish returned a nil ParcelFileDescriptor")
 		return errVPNNotPrepared
 	}
 


### PR DESCRIPTION
Switch state is determined by the VPN interface state and Tailscale state. Because the user is able to see other devices on the network and the admin console shows the Android device, my guess is that there is something going on with the VPN connection. This adds logging to track the establishment of the VPN interface.

Updates tailscale/tailscale#15506