### PR TITLE
android: fix IllegalStateException in navigation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -139,7 +139,7 @@ dependencies {
     implementation "androidx.compose.animation:animation:1.7.4"
 
     // Navigation dependencies.
-    def nav_version = "2.8.2"
+    def nav_version = "2.8.5"
     implementation "androidx.navigation:navigation-compose:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
 


### PR DESCRIPTION
Update to androidx.navigation 2.8.5: this fixes the NavHost exception per https://developer.android.com/jetpack/androidx/releases/navigation#2.8.5

Fixes tailscale/tailscale#15755