### PR TITLE
mdm: define TailscaleOnboardingSeen syspolicy on Android

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/MainActivity.kt
+++ b/android/src/main/java/com/tailscale/ipn/MainActivity.kt
@@ -292,7 +292,7 @@ class MainActivity : ComponentActivity() {
                 }
 
             // Show the intro screen one time
-            if (!introScreenViewed()) {
+            if (!introScreenViewed() && !mdmTailscaleOnboardingSeen()) {
               navController.navigate("intro")
               setIntroScreenViewed(true)
             }
@@ -455,6 +455,10 @@ class MainActivity : ComponentActivity() {
         .edit()
         .putBoolean("seen", seen)
         .apply()
+  }
+
+  private fun mdmTailscaleOnboardingSeen(): Boolean {
+    return MDMSettings.tailscaleOnboardingSeen.flow.value.value
   }
 }
 

--- a/android/src/main/java/com/tailscale/ipn/mdm/MDMSettings.kt
+++ b/android/src/main/java/com/tailscale/ipn/mdm/MDMSettings.kt
@@ -97,6 +97,9 @@ object MDMSettings {
   // Overrides the value provided by os.Hostname() in Go
   val hostname = StringMDMSetting("Hostname", "Device Hostname")
 
+  // Allows admins to skip the get started intro screen
+  val tailscaleOnboardingSeen = BooleanMDMSetting("TailscaleOnboardingSeen", "Suppress the intro screen")
+
   val allSettings by lazy {
     MDMSettings::class
         .declaredMemberProperties

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -214,6 +214,8 @@
     <string name="run_as_exit_node_visibility">Run as exit node visibility</string>
     <string name="defines_an_auth_key_that_will_be_used_for_login">Defines an auth key that will be used for login.</string>
     <string name="auth_key">Auth Key</string>
+    <string name="skips_the_intro_page_shown_to_users_that_open_the_app_for_the_first_time">Skips the intro page shown to users that open the app for the first time</string>
+    <string name="tailscale_onboarding_seen">Mark Onboarding Page as Seen</string>
 
     <!-- Permissions Management -->
     <string name="permissions">Permissions</string>

--- a/android/src/main/res/xml/app_restrictions.xml
+++ b/android/src/main/res/xml/app_restrictions.xml
@@ -134,4 +134,10 @@
         android:key="Hostname"
         android:restrictionType="string"
         android:title="@string/hostname" />
+
+    <restriction
+        android:description="@string/skips_the_intro_page_shown_to_users_that_open_the_app_for_the_first_time"
+        android:key="TailscaleOnboardingSeen"
+        android:restrictionType="bool"
+        android:title="@string/tailscale_onboarding_seen" />
 </restrictions>


### PR DESCRIPTION
Adds an MDM setting `TailscaleOnboardingSeen` which allows for the intro screen to be skipped when set to true.

Updates https://github.com/tailscale/corp/issues/27966