### PR TITLE
android: replace broadcast intent with service intent

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/IPNService.kt
+++ b/android/src/main/java/com/tailscale/ipn/IPNService.kt
@@ -12,12 +12,12 @@ import com.tailscale.ipn.mdm.MDMSettings
 import com.tailscale.ipn.ui.model.Ipn
 import com.tailscale.ipn.ui.notifier.Notifier
 import com.tailscale.ipn.util.TSLog
-import java.util.UUID
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import libtailscale.Libtailscale
+import java.util.UUID
 
 open class IPNService : VpnService(), libtailscale.IPNService {
   private val TAG = "IPNService"
@@ -44,6 +44,13 @@ open class IPNService : VpnService(), libtailscale.IPNService {
         ACTION_STOP_VPN -> {
           app.setWantRunning(false)
           close()
+          START_NOT_STICKY
+        }
+        ACTION_RESTART_VPN -> {
+          app.setWantRunning(false){
+            close()
+            app.startVPN()
+          }
           START_NOT_STICKY
         }
         ACTION_START_VPN -> {
@@ -82,7 +89,6 @@ open class IPNService : VpnService(), libtailscale.IPNService {
       }
 
   override fun close() {
-    app.setWantRunning(false) {}
     Notifier.setState(Ipn.State.Stopping)
     disconnectVPN()
     Libtailscale.serviceDisconnect(this)
@@ -180,5 +186,6 @@ open class IPNService : VpnService(), libtailscale.IPNService {
   companion object {
     const val ACTION_START_VPN = "com.tailscale.ipn.START_VPN"
     const val ACTION_STOP_VPN = "com.tailscale.ipn.STOP_VPN"
+    const val ACTION_RESTART_VPN = "com.tailscale.ipn.RESTART_VPN"
   }
 }

--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/SplitTunnelAppPickerViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/SplitTunnelAppPickerViewModel.kt
@@ -4,14 +4,18 @@
 package com.tailscale.ipn.ui.viewModel
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.tailscale.ipn.App
 import com.tailscale.ipn.mdm.MDMSettings
 import com.tailscale.ipn.mdm.SettingState
 import com.tailscale.ipn.ui.util.InstalledApp
 import com.tailscale.ipn.ui.util.InstalledAppsManager
 import com.tailscale.ipn.ui.util.set
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 
 class SplitTunnelAppPickerViewModel : ViewModel() {
   val installedAppsManager = InstalledAppsManager(packageManager = App.get().packageManager)
@@ -19,6 +23,8 @@ class SplitTunnelAppPickerViewModel : ViewModel() {
   val installedApps: StateFlow<List<InstalledApp>> = MutableStateFlow(listOf())
   val mdmExcludedPackages: StateFlow<SettingState<String?>> = MDMSettings.excludedPackages.flow
   val mdmIncludedPackages: StateFlow<SettingState<String?>> = MDMSettings.includedPackages.flow
+
+  private var saveJob: Job? = null
 
   init {
     installedApps.set(installedAppsManager.fetchInstalledApps())
@@ -30,15 +36,22 @@ class SplitTunnelAppPickerViewModel : ViewModel() {
   }
 
   fun exclude(packageName: String) {
-    if (excludedPackageNames.value.contains(packageName)) {
-      return
-    }
+    if (excludedPackageNames.value.contains(packageName)) return
     excludedPackageNames.set(excludedPackageNames.value + packageName)
-    App.get().addUserDisallowedPackageName(packageName)
+    debounceSave()
   }
 
   fun unexclude(packageName: String) {
     excludedPackageNames.set(excludedPackageNames.value - packageName)
-    App.get().removeUserDisallowedPackageName(packageName)
+    debounceSave()
+  }
+
+  private fun debounceSave() {
+    saveJob?.cancel()
+    saveJob =
+        viewModelScope.launch {
+          delay(500) // Wait to batch multiple rapid updates
+          App.get().updateUserDisallowedPackageNames(excludedPackageNames.value)
+        }
   }
 }


### PR DESCRIPTION
We were previously calling startService(intent), which is a direct call consumed by IPNService, but restartVPN was not working as intended because the broadcast receiver was never triggered. Rather than use a broadcast receiver, directly start the service in restartVPN as we do in stopVPN. Also, batch changes to excluded apps so that we don't restart the VPN each time the user toggles an app.

Fixes tailscale/corp#28668