### PR TITLE
android: be stricter about system backups

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -32,6 +32,8 @@
     <application
         android:name=".App"
         android:allowBackup="false"
+        android:fullBackupContent="@xml/backup_rules"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:banner="@drawable/tv_banner"
         android:icon="@mipmap/ic_launcher"
         android:label="Tailscale"

--- a/android/src/main/res/xml/backup_rules.xml
+++ b/android/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,9 @@
+<?kml version="1.0" encoding="utf-8"?>
+<!-- data_extraction_rules but for devices below Android 12 -->
+<full-backup-content>
+    <exclude domain="root"/>
+    <exclude domain="file"/>
+    <exclude domain="database"/>
+    <exclude domain="sharedpref"/>
+    <exclude domain="external"/>
+</full-backup-content>

--- a/android/src/main/res/xml/data_extraction_rules.xml
+++ b/android/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not allow system backups, including in device-transfer which ignores allowBackup, to not break Tailscale when restoring -->
+<!-- It would be nice to have only preferences backed up or some mechanism in-app to solve issues caused by KeyStore not being backed up -->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="root"/>
+        <exclude domain="file"/>
+        <exclude domain="database"/>
+        <exclude domain="sharedpref"/>
+        <exclude domain="external"/>
+    </cloud-backup>
+
+    <device-transfer>
+        <exclude domain="root"/>
+        <exclude domain="file"/>
+        <exclude domain="database"/>
+        <exclude domain="sharedpref"/>
+        <exclude domain="external"/>
+    </device-transfer>
+</data-extraction-rules>


### PR DESCRIPTION
we should also exclude D2D because it also does not work and results in a broken state