### PR TITLE
android: add explanatory dialog for taildrop directory selection

### DIFF
--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -324,4 +324,10 @@
     <string name="hostname">Hostname</string>
     <string name="failed_to_save">Failed to save</string>
 
+    <!-- Strings for the taildrop directory picker interstitial -->
+    <string name="taildrop_directory_picker_title">Taildrop Directory</string>
+    <string name="taildrop_directory_picker_body">You have not selected a directory for incoming taildrop transfers. Please select or create a target directory.</string>
+    <string name="taildrop_directory_picker_info">What is taildrop?</string>
+    <string name="taildrop_directory_picker_button">Open Directory Picker</string>
+
 </resources>


### PR DESCRIPTION
fixes tailscale/corp#29067

Adds an interstitial explaining that the user needs to select/create a taildrop target directory on startup.