### PR TITLE
android: allow users to update taildrop directory

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/TaildropDirectoryStore.kt
+++ b/android/src/main/java/com/tailscale/ipn/TaildropDirectoryStore.kt
@@ -1,0 +1,43 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package com.tailscale.ipn
+
+import android.net.Uri
+import com.tailscale.ipn.util.TSLog
+import java.io.IOException
+import java.security.GeneralSecurityException
+
+object TaildropDirectoryStore {
+  // Key to store the SAF URI in EncryptedSharedPreferences.
+  val PREF_KEY_SAF_URI = "saf_directory_uri"
+
+  @Throws(IOException::class, GeneralSecurityException::class)
+  fun saveFileDirectory(directoryUri: Uri) {
+    val prefs = App.get().getEncryptedPrefs()
+    prefs.edit().putString(PREF_KEY_SAF_URI, directoryUri.toString()).apply()
+    try {
+      // Must restart Tailscale because a new LocalBackend with the new directory must be created.
+      App.get().startLibtailscale(directoryUri.toString())
+    } catch (e: Exception) {
+      TSLog.d(
+          "TaildropDirectoryStore",
+          "saveFileDirectory: Failed to restart Libtailscale with the new directory: $e")
+    }
+  }
+
+  @Throws(IOException::class, GeneralSecurityException::class)
+  fun loadSavedDir(): Uri? {
+    val prefs = App.get().getEncryptedPrefs()
+    val uriString = prefs.getString(PREF_KEY_SAF_URI, null) ?: return null
+
+    return try {
+      Uri.parse(uriString)
+    } catch (e: Exception) {
+      // Malformed URI in prefs ‑‑ log and wipe the bad value
+      TSLog.w("MainActivity", "loadSavedDir: invalid URI in prefs: $uriString; clearing")
+      prefs.edit().remove(PREF_KEY_SAF_URI).apply()
+      null
+    }
+  }
+}

--- a/android/src/main/java/com/tailscale/ipn/ui/util/PermissionsDisplayUtil.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/util/PermissionsDisplayUtil.kt
@@ -1,0 +1,21 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package com.tailscale.ipn.ui.util
+
+import android.net.Uri
+
+/** Converts a SAF URI string to a more human-friendly folder display name. */
+fun friendlyDirName(uriStr: String): String {
+  val uri = Uri.parse(uriStr)
+  val segment = uri.lastPathSegment ?: return uriStr
+
+  return when {
+    segment.startsWith("primary:") -> "Internal storage › " + segment.removePrefix("primary:")
+    segment.contains(":") -> {
+      val folder = segment.substringAfter(":")
+      "SD card › $folder"
+    }
+    else -> segment
+  }
+}

--- a/android/src/main/java/com/tailscale/ipn/ui/view/NotificationsView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/NotificationsView.kt
@@ -1,0 +1,93 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package com.tailscale.ipn.ui.view
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Button
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.tailscale.ipn.R
+import com.tailscale.ipn.ui.model.Permissions
+import com.tailscale.ipn.ui.theme.exitNodeToggleButton
+
+@Composable
+fun NotificationsView(backToPermissionsView: BackNavigation, openApplicationSettings: () -> Unit) {
+  val permissions = Permissions.withGrantedStatus
+
+  // Find the notification permission
+  val notificationPermission =
+      permissions.find { (permission, _) ->
+        permission.title == R.string.permission_post_notifications
+      }
+  val granted = notificationPermission?.second ?: false
+  val permission = notificationPermission?.first
+
+  Scaffold(
+      topBar = {
+        Header(titleRes = R.string.permission_post_notifications, onBack = backToPermissionsView)
+      }) { innerPadding ->
+        LazyColumn(modifier = Modifier.padding(innerPadding)) {
+          item {
+            if (permission != null) {
+              ListItem(
+                  headlineContent = {
+                    Text(
+                        stringResource(permission.title),
+                        style = MaterialTheme.typography.titleMedium)
+                  },
+                  supportingContent = {
+                    Column(modifier = Modifier.fillMaxWidth()) {
+                      Text(
+                          text = stringResource(permission.description),
+                          style = MaterialTheme.typography.bodyMedium)
+                      Spacer(modifier = Modifier.height(12.dp))
+                      Text(
+                          text = stringResource(R.string.notification_settings_explanation),
+                          style = MaterialTheme.typography.bodyMedium)
+                    }
+                  })
+            }
+          }
+
+          item("spacer") {
+            Spacer(modifier = Modifier.height(16.dp)) // soft break instead of divider
+          }
+
+          item {
+            ListItem(
+                headlineContent = {
+                  Text(
+                      text = stringResource(R.string.permission_post_notifications),
+                      style = MaterialTheme.typography.titleMedium)
+                },
+                supportingContent = {
+                  Column(modifier = Modifier.fillMaxWidth()) {
+                    Text(
+                        text =
+                            if (granted) stringResource(R.string.on)
+                            else stringResource(R.string.off),
+                        style = MaterialTheme.typography.bodyMedium)
+                    Button(
+                        colors = MaterialTheme.colorScheme.exitNodeToggleButton,
+                        onClick = openApplicationSettings,
+                        modifier = Modifier.fillMaxWidth().padding(top = 12.dp)) {
+                          Text(stringResource(R.string.open_notification_settings))
+                        }
+                  }
+                })
+          }
+        }
+      }
+}

--- a/android/src/main/java/com/tailscale/ipn/ui/view/PermissionsView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/PermissionsView.kt
@@ -17,29 +17,33 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.tailscale.ipn.R
 import com.tailscale.ipn.ui.model.Permissions
-import com.tailscale.ipn.ui.theme.success
+import com.tailscale.ipn.ui.util.friendlyDirName
 import com.tailscale.ipn.ui.util.itemsWithDividers
+import com.tailscale.ipn.ui.viewModel.PermissionsViewModel
 
-@OptIn(ExperimentalPermissionsApi::class)
 @Composable
-fun PermissionsView(backToSettings: BackNavigation, openApplicationSettings: () -> Unit) {
+fun PermissionsView(
+    backToSettings: BackNavigation,
+    navToTaildropDirView: () -> Unit,
+    navToNotificationsView: () -> Unit,
+    permissionsViewModel: PermissionsViewModel = viewModel()
+) {
   val permissions = Permissions.withGrantedStatus
+
   Scaffold(topBar = { Header(titleRes = R.string.permissions, onBack = backToSettings) }) {
       innerPadding ->
     LazyColumn(modifier = Modifier.padding(innerPadding)) {
+      // Existing Android runtime permissions
       itemsWithDividers(permissions) { (permission, granted) ->
         ListItem(
-            modifier = Modifier.clickable { openApplicationSettings() },
+            modifier = Modifier.clickable { navToNotificationsView() },
             leadingContent = {
               Icon(
-                  if (granted) painterResource(R.drawable.check_circle)
-                  else painterResource(R.drawable.xmark_circle),
-                  tint =
-                      if (granted) MaterialTheme.colorScheme.success
-                      else MaterialTheme.colorScheme.onSurfaceVariant,
+                  painterResource(R.drawable.baseline_notifications_none_24),
+                  tint = MaterialTheme.colorScheme.onSurfaceVariant,
                   modifier = Modifier.size(24.dp),
                   contentDescription =
                       stringResource(if (granted) R.string.ok else R.string.warning))
@@ -47,8 +51,32 @@ fun PermissionsView(backToSettings: BackNavigation, openApplicationSettings: () 
             headlineContent = {
               Text(stringResource(permission.title), style = MaterialTheme.typography.titleMedium)
             },
-            supportingContent = { Text(stringResource(permission.description)) },
-        )
+            supportingContent = {
+              if (granted) Text(stringResource(R.string.on)) else Text(stringResource(R.string.off))
+            })
+      }
+
+      item {
+        ListItem(
+            modifier = Modifier.clickable { navToTaildropDirView() },
+            leadingContent = {
+              Icon(
+                  painterResource(R.drawable.baseline_drive_folder_upload_24),
+                  tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                  modifier = Modifier.size(24.dp),
+                  contentDescription = stringResource(R.string.taildrop_dir))
+            },
+            headlineContent = {
+              Text(
+                  stringResource(R.string.taildrop_dir_access),
+                  style = MaterialTheme.typography.titleMedium)
+            },
+            supportingContent = {
+              val displayPath =
+                  permissionsViewModel.currentDir.value?.let { friendlyDirName(it) } ?: "No access"
+
+              Text(displayPath)
+            })
       }
     }
   }

--- a/android/src/main/java/com/tailscale/ipn/ui/view/TaildropDirView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/TaildropDirView.kt
@@ -1,0 +1,79 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package com.tailscale.ipn.ui.view
+
+import android.net.Uri
+import androidx.activity.result.ActivityResultLauncher
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Button
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.tailscale.ipn.R
+import com.tailscale.ipn.ui.theme.exitNodeToggleButton
+import com.tailscale.ipn.ui.util.Lists
+import com.tailscale.ipn.ui.util.friendlyDirName
+import com.tailscale.ipn.ui.viewModel.PermissionsViewModel
+
+@Composable
+fun TaildropDirView(
+    backToPermissionsView: BackNavigation,
+    openDirectoryLauncher: ActivityResultLauncher<Uri?>,
+    permissionsViewModel: PermissionsViewModel = viewModel()
+) {
+  Scaffold(
+      topBar = {
+        Header(titleRes = R.string.taildrop_dir_access, onBack = backToPermissionsView)
+      }) { innerPadding ->
+        LazyColumn(modifier = Modifier.padding(innerPadding)) {
+          item {
+            ListItem(
+                headlineContent = {
+                  Text(
+                      stringResource(R.string.taildrop_dir_access),
+                      style = MaterialTheme.typography.titleMedium)
+                },
+                supportingContent = {
+                  Text(
+                      text = stringResource(R.string.permission_taildrop_dir),
+                      style = MaterialTheme.typography.bodyMedium)
+                })
+          }
+
+          item("divider0") { Lists.SectionDivider() }
+
+          item {
+            val currentDir = permissionsViewModel.currentDir.value
+            val displayPath = currentDir?.let { friendlyDirName(it) } ?: "No access"
+
+            ListItem(
+                headlineContent = {
+                  Text(
+                      text = stringResource(R.string.dir_access),
+                      style = MaterialTheme.typography.titleMedium)
+                },
+                supportingContent = {
+                  Column(modifier = Modifier.fillMaxWidth()) {
+                    Text(text = displayPath, style = MaterialTheme.typography.bodyMedium)
+                    Button(
+                        colors = MaterialTheme.colorScheme.exitNodeToggleButton,
+                        onClick = { openDirectoryLauncher.launch(null) },
+                        modifier = Modifier.fillMaxWidth().padding(top = 12.dp)) {
+                          Text(stringResource(R.string.pick_dir))
+                        }
+                  }
+                })
+          }
+        }
+      }
+}

--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/PermissionsViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/PermissionsViewModel.kt
@@ -1,0 +1,39 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package com.tailscale.ipn.ui.viewModel
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import com.tailscale.ipn.TaildropDirectoryStore
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import libtailscale.Libtailscale
+
+class PermissionsViewModel(private val savedStateHandle: SavedStateHandle) : ViewModel() {
+
+  private val _currentDir =
+      MutableStateFlow<String?>(TaildropDirectoryStore.loadSavedDir().toString())
+  val currentDir: StateFlow<String?> = _currentDir
+
+  fun onDirectoryPicked(uri: Uri?, context: Context) {
+    if (uri == null) return
+
+    val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+    val cr = context.contentResolver
+
+    // Revoke previous grant so you don’t leak one
+    _currentDir.value?.let { old ->
+      runCatching { cr.releasePersistableUriPermission(Uri.parse(old), flags) }
+    }
+
+    cr.takePersistableUriPermission(uri, flags) // may throw SecurityException
+    Libtailscale.setDirectFileRoot(uri.toString())
+    TaildropDirectoryStore.saveFileDirectory(uri)
+
+    _currentDir.value = uri.toString()
+  }
+}

--- a/android/src/main/res/drawable/baseline_drive_folder_upload_24.xml
+++ b/android/src/main/res/drawable/baseline_drive_folder_upload_24.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:tint="#000000">
+
+    <!-- Folder outline -->
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M20,6h-8l-2,-2L4,4c-1.1,0 -1.99,0.9 -1.99,2L2,18c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,8c0,-1.1 -0.9,-2 -2,-2zM20,18L4,18L4,8h16v10z" />
+
+    <!-- Flipped arrow, shifted downward by 1dp (in viewport units) -->
+    <group
+        android:translateY="2">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M16,10.99l-1.41,-1.41L13,11.16V7h-2v4.16L9.41,9.58 8,10.99 12.01,15 16,10.99z" />
+    </group>
+</vector>

--- a/android/src/main/res/drawable/baseline_folder_open_24.xml
+++ b/android/src/main/res/drawable/baseline_folder_open_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M20,6h-8l-2,-2L4,4c-1.1,0 -1.99,0.9 -1.99,2L2,18c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,8c0,-1.1 -0.9,-2 -2,-2zM20,18L4,18L4,8h16v10z"/>
+    
+</vector>

--- a/android/src/main/res/drawable/baseline_notifications_none_24.xml
+++ b/android/src/main/res/drawable/baseline_notifications_none_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M12,22c1.1,0 2,-0.9 2,-2h-4c0,1.1 0.9,2 2,2zM18,16v-5c0,-3.07 -1.63,-5.64 -4.5,-6.32L13.5,4c0,-0.83 -0.67,-1.5 -1.5,-1.5s-1.5,0.67 -1.5,1.5v0.68C7.64,5.36 6,7.92 6,11v5l-2,2v1h16v-1l-2,-2zM16,17L8,17v-6c0,-2.48 1.51,-4.5 4,-4.5s4,2.02 4,4.5v6z"/>
+    
+</vector>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -24,6 +24,8 @@
     <string name="no_results">No results</string>
     <string name="back">Back</string>
     <string name="clear_search">Clear search</string>
+    <string name="off">Off</string>
+    <string name="on">On</string>
 
     <!-- Strings for the about screen -->
     <string name="app_name" translatable="false">Tailscale</string>
@@ -221,7 +223,13 @@
     <string name="permission_write_external_storage_needed">We use storage in order to receive files with Taildrop.</string>
     <string name="permission_post_notifications">Notifications</string>
     <string name="permission_post_notifications_needed">We use notifications to help you troubleshoot broken connections, or notify you before you need to reauthenticate to your network. Persistent status notifications are off by default and can be enabled in system settings. </string>
-
+    <string name="open_notification_settings">Go to notification settings</string>
+    <string name="notification_settings_explanation">Persistent status notifications are off by default and can be enabled in system settings.</string>
+    <string name="taildrop_dir">Taildrop directory</string>
+    <string name="taildrop_dir_access">Taildrop directory access</string>
+    <string name="permission_taildrop_dir">Give Tailscale access to a folder in order to be able to download incoming files sent to you via Taildrop.</string>
+    <string name="dir_access">Directory access</string>
+    <string name="pick_dir">Pick a different directory</string>
 
     <!-- Strings for the share activity -->
     <string name="share">Send with Taildrop</string>


### PR DESCRIPTION

![Screenshot_20250529-144942](https://github.com/user-attachments/assets/9bcc1859-a88b-44dc-a0fc-4551bfcf83ab)
![Screenshot_20250529-144935](https://github.com/user-attachments/assets/9ee5c290-be09-490c-8215-7d8c55e97910)
![Screenshot_20250529-144858](https://github.com/user-attachments/assets/2ed09612-f56b-42d0-8037-0c596844cf5a)
-Modify Permissions view to navigate to Taildrop dir view and Notifications view, and to reflect state -Add Taildrop dir view which navigates to directory selector -Add Notifications view which navigates to Taildrop notifications setting

Updates tailscale/tailscale#15263