### PR TITLE
android: detect amazon fire stick as a AndroidTV

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/ui/util/AndroidTVUtil.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/util/AndroidTVUtil.kt
@@ -13,10 +13,13 @@ import com.tailscale.ipn.UninitializedApp
 import com.tailscale.ipn.ui.util.AndroidTVUtil.isAndroidTV
 
 object AndroidTVUtil {
+  private val FEATURE_FIRETV = "amazon.hardware.fire_tv"
+
   fun isAndroidTV(): Boolean {
     val pm = UninitializedApp.get().packageManager
     return (pm.hasSystemFeature(@Suppress("deprecation") PackageManager.FEATURE_TELEVISION) ||
-        pm.hasSystemFeature(PackageManager.FEATURE_LEANBACK))
+        pm.hasSystemFeature(PackageManager.FEATURE_LEANBACK) ||
+        pm.hasSystemFeature(FEATURE_FIRETV))
   }
 }
 


### PR DESCRIPTION
fixes tailscale/tailscale#16164

We weren't detecting fire stick devices as TV devices.