### PR TITLE
android: add All() to state store implementation

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/App.kt
+++ b/android/src/main/java/com/tailscale/ipn/App.kt
@@ -248,6 +248,16 @@ class App : UninitializedApp(), libtailscale.AppContext, ViewModelStoreOwner {
     return getEncryptedPrefs().getString(prefKey, null)
   }
 
+  override fun getStateStoreKeysJSON(): String {
+    val prefix = "statestore-"
+    val keys = getEncryptedPrefs()
+                  .getAll()
+                  .keys
+                  .filter { it.startsWith(prefix) }
+                  .map   { it.removePrefix(prefix) }
+    return org.json.JSONArray(keys).toString()
+  }
+
   @Throws(IOException::class, GeneralSecurityException::class)
   fun getEncryptedPrefs(): SharedPreferences {
     val key = MasterKey.Builder(this).setKeyScheme(MasterKey.KeyScheme.AES256_GCM).build()

--- a/libtailscale/interfaces.go
+++ b/libtailscale/interfaces.go
@@ -29,6 +29,10 @@ type AppContext interface {
 	// at the given key, or returns empty string if unset.
 	DecryptFromPref(key string) (string, error)
 
+	// GetStateStoreKeysJson retrieves all keys stored in the encrypted SharedPreferences,
+	// strips off the "statestore-" prefix, and returns them as a JSON array.
+	GetStateStoreKeysJSON() string
+
 	// GetOSVersion gets the Android version.
 	GetOSVersion() (string, error)
 


### PR DESCRIPTION
Android has its own SharedPreferences-backed implementation of ipn.StateStore. Due to https://github.com/golang/go/issues/13445, we bundle the key list into a single primitive and unpack it in Go in our All() implementation. This also adds a compile-time check to prevent drift the interface.

Updates tailscale/tailscale#15830