### PR TITLE
android: defer taildrop selector until first taildrop attempt (#684)

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/MainActivity.kt
+++ b/android/src/main/java/com/tailscale/ipn/MainActivity.kt
@@ -34,10 +34,18 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.core.net.toUri
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.ViewModelProvider
@@ -75,39 +83,38 @@ import com.tailscale.ipn.ui.view.MullvadInfoView
 import com.tailscale.ipn.ui.view.NotificationsView
 import com.tailscale.ipn.ui.view.PeerDetails
 import com.tailscale.ipn.ui.view.PermissionsView
+import com.tailscale.ipn.ui.view.PrimaryActionButton
 import com.tailscale.ipn.ui.view.RunExitNodeView
 import com.tailscale.ipn.ui.view.SearchView
 import com.tailscale.ipn.ui.view.SettingsView
 import com.tailscale.ipn.ui.view.SplitTunnelAppPickerView
 import com.tailscale.ipn.ui.view.SubnetRoutingView
 import com.tailscale.ipn.ui.view.TaildropDirView
+import com.tailscale.ipn.ui.view.TaildropDirectoryPickerPrompt
 import com.tailscale.ipn.ui.view.TailnetLockSetupView
 import com.tailscale.ipn.ui.view.UserSwitcherNav
 import com.tailscale.ipn.ui.view.UserSwitcherView
+import com.tailscale.ipn.ui.viewModel.AppViewModel
 import com.tailscale.ipn.ui.viewModel.ExitNodePickerNav
 import com.tailscale.ipn.ui.viewModel.MainViewModel
 import com.tailscale.ipn.ui.viewModel.MainViewModelFactory
 import com.tailscale.ipn.ui.viewModel.PermissionsViewModel
 import com.tailscale.ipn.ui.viewModel.PingViewModel
 import com.tailscale.ipn.ui.viewModel.SettingsNav
-import com.tailscale.ipn.ui.viewModel.VpnViewModel
+import com.tailscale.ipn.util.ShareFileHelper
 import com.tailscale.ipn.util.TSLog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import libtailscale.Libtailscale
 
 class MainActivity : ComponentActivity() {
   private lateinit var navController: NavHostController
   private lateinit var vpnPermissionLauncher: ActivityResultLauncher<Intent>
-  private val viewModel: MainViewModel by lazy {
-    val app = App.get()
-    vpnViewModel = app.getAppScopedViewModel()
-    ViewModelProvider(this, MainViewModelFactory(vpnViewModel)).get(MainViewModel::class.java)
-  }
-  private lateinit var vpnViewModel: VpnViewModel
+  private lateinit var appViewModel: AppViewModel
+  private lateinit var viewModel: MainViewModel
+
   val permissionsViewModel: PermissionsViewModel by viewModels()
 
   companion object {
@@ -119,7 +126,6 @@ class MainActivity : ComponentActivity() {
     return (resources.configuration.screenLayout and SCREENLAYOUT_SIZE_MASK) >=
         SCREENLAYOUT_SIZE_LARGE
   }
-
   // The loginQRCode is used to track whether or not we should be rendering a QR code
   // to the user.  This is used only on TV platforms with no browser in lieu of
   // simply opening the URL.  This should be consumed once it has been handled.
@@ -132,29 +138,27 @@ class MainActivity : ComponentActivity() {
 
     // grab app to make sure it initializes
     App.get()
-    vpnViewModel = ViewModelProvider(App.get()).get(VpnViewModel::class.java)
+    appViewModel = (application as App).getAppScopedViewModel()
+    viewModel =
+        ViewModelProvider(this, MainViewModelFactory(appViewModel)).get(MainViewModel::class.java)
 
     val rm = getSystemService(Context.RESTRICTIONS_SERVICE) as RestrictionsManager
     MDMSettings.update(App.get(), rm)
-
     if (MDMSettings.onboardingFlow.flow.value.value == ShowHide.Hide ||
         MDMSettings.authKey.flow.value.value != null) {
       setIntroScreenViewed(true)
     }
-
     // (jonathan) TODO: Force the app to be portrait on small screens until we have
     // proper landscape layout support
     if (!isLandscapeCapable()) {
       requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
     }
-
     installSplashScreen()
-
     vpnPermissionLauncher =
         registerForActivityResult(VpnPermissionContract()) { granted ->
           if (granted) {
             TSLog.d("VpnPermission", "VPN permission granted")
-            vpnViewModel.setVpnPrepared(true)
+            appViewModel.setVpnPrepared(true)
             App.get().startVPN()
           } else {
             if (isAnotherVpnActive(this)) {
@@ -162,7 +166,7 @@ class MainActivity : ComponentActivity() {
               showOtherVPNConflictDialog()
             } else {
               TSLog.d("VpnPermission", "Permission was denied by the user")
-              vpnViewModel.setVpnPrepared(false)
+              appViewModel.setVpnPrepared(false)
 
               AlertDialog.Builder(this)
                   .setTitle(R.string.vpn_permission_needed)
@@ -176,7 +180,6 @@ class MainActivity : ComponentActivity() {
           }
         }
     viewModel.setVpnPermissionLauncher(vpnPermissionLauncher)
-
     val directoryPickerLauncher =
         registerForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri: Uri? ->
           if (uri != null) {
@@ -188,7 +191,6 @@ class MainActivity : ComponentActivity() {
             } catch (e: SecurityException) {
               TSLog.e("MainActivity", "Failed to persist permissions: $e")
             }
-
             // Check if write permission is actually granted.
             val writePermission =
                 this.checkUriPermission(
@@ -198,9 +200,10 @@ class MainActivity : ComponentActivity() {
 
               lifecycleScope.launch(Dispatchers.IO) {
                 try {
-                  Libtailscale.setDirectFileRoot(uri.toString())
                   TaildropDirectoryStore.saveFileDirectory(uri)
                   permissionsViewModel.refreshCurrentDir()
+                  ShareFileHelper.notifyDirectoryReady()
+                  ShareFileHelper.setUri(uri.toString())
                 } catch (e: Exception) {
                   TSLog.e("MainActivity", "Failed to set Taildrop root: $e")
                 }
@@ -214,14 +217,40 @@ class MainActivity : ComponentActivity() {
           } else {
             TSLog.d(
                 "MainActivity", "Taildrop directory not saved. Will fall back to internal storage.")
-
             // Fall back to internal storage.
           }
         }
 
-    viewModel.setDirectoryPickerLauncher(directoryPickerLauncher)
+    appViewModel.directoryPickerLauncher = directoryPickerLauncher
 
     setContent {
+       var showDialog by remember { mutableStateOf(false) }
+
+      LaunchedEffect(Unit) { appViewModel.triggerDirectoryPicker.collect { showDialog = true } }
+
+      if (showDialog) {
+        AppTheme {
+          AlertDialog(
+              onDismissRequest = {
+                showDialog = false
+                appViewModel.directoryPickerLauncher?.launch(null)
+              },
+              title = {
+                Text(text = stringResource(id = R.string.taildrop_directory_picker_title))
+              },
+              text = { TaildropDirectoryPickerPrompt() },
+              confirmButton = {
+                PrimaryActionButton(
+                    onClick = {
+                      showDialog = false
+                      appViewModel.directoryPickerLauncher?.launch(null)
+                    }) {
+                      Text(text = stringResource(id = R.string.taildrop_directory_picker_button))
+                    }
+              })
+        }
+      }
+
       navController = rememberNavController()
 
       AppTheme {
@@ -257,7 +286,6 @@ class MainActivity : ComponentActivity() {
                   fun backTo(route: String): () -> Unit = {
                     navController.popBackStack(route = route, inclusive = false)
                   }
-
                   val mainViewNav =
                       MainViewNavigation(
                           onNavigateToSettings = { navController.navigate("settings") },
@@ -270,7 +298,6 @@ class MainActivity : ComponentActivity() {
                             viewModel.enableSearchAutoFocus()
                             navController.navigate("search")
                           })
-
                   val settingsNav =
                       SettingsNav(
                           onNavigateToBugReport = { navController.navigate("bugReport") },
@@ -285,7 +312,6 @@ class MainActivity : ComponentActivity() {
                           onNavigateToPermissions = { navController.navigate("permissions") },
                           onBackToSettings = backTo("settings"),
                           onNavigateBackHome = backTo("main"))
-
                   val exitNodePickerNav =
                       ExitNodePickerNav(
                           onNavigateBackHome = {
@@ -297,7 +323,6 @@ class MainActivity : ComponentActivity() {
                           onNavigateBackToMullvad = backTo("mullvad"),
                           onNavigateToMullvadCountry = { navController.navigate("mullvad/$it") },
                           onNavigateToRunAsExitNode = { navController.navigate("runExitNode") })
-
                   val userSwitcherNav =
                       UserSwitcherNav(
                           backToSettings = backTo("settings"),
@@ -308,7 +333,11 @@ class MainActivity : ComponentActivity() {
                           onNavigateToAuthKey = { navController.navigate("loginWithAuthKey") })
 
                   composable("main", enterTransition = { fadeIn(animationSpec = tween(150)) }) {
-                    MainView(loginAtUrl = ::login, navigation = mainViewNav, viewModel = viewModel)
+                    MainView(
+                        loginAtUrl = ::login,
+                        navigation = mainViewNav,
+                        viewModel = viewModel,
+                        appViewModel = appViewModel)
                   }
                   composable("search") {
                     val autoFocus = viewModel.autoFocusSearch
@@ -318,7 +347,9 @@ class MainActivity : ComponentActivity() {
                         onNavigateBack = { navController.popBackStack() },
                         autoFocus = autoFocus)
                   }
-                  composable("settings") { SettingsView(settingsNav) }
+                  composable("settings") {
+                    SettingsView(settingsNav = settingsNav, appViewModel = appViewModel)
+                  }
                   composable("exitNodes") { ExitNodePicker(exitNodePickerNav) }
                   composable("health") { HealthView(backTo("main")) }
                   composable("mullvad") { MullvadExitNodePickerList(exitNodePickerNav) }
@@ -378,7 +409,6 @@ class MainActivity : ComponentActivity() {
             }
           }
         }
-
         // Login actions are app wide.  If we are told about a browse-to-url, we should render it
         // over whatever screen we happen to be on.
         loginQRCode.collectAsState().value?.let {
@@ -401,7 +431,6 @@ class MainActivity : ComponentActivity() {
         }
       }
     }
-
     // Once we see a loginFinished event, clear the QR code which will dismiss the QR dialog.
     lifecycleScope.launch { Notifier.loginFinished.collect { _ -> loginQRCode.set(null) } }
   }
@@ -422,7 +451,6 @@ class MainActivity : ComponentActivity() {
   fun isAnotherVpnActive(context: Context): Boolean {
     val connectivityManager =
         context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-
     val activeNetwork = connectivityManager.activeNetwork
     if (activeNetwork != null) {
       val networkCapabilities = connectivityManager.getNetworkCapabilities(activeNetwork)
@@ -433,7 +461,6 @@ class MainActivity : ComponentActivity() {
     }
     return false
   }
-
   // Returns true if we should render a QR code instead of launching a browser
   // for login requests
   private fun useQRCodeLogin(): Boolean {
@@ -449,7 +476,6 @@ class MainActivity : ComponentActivity() {
         if (this::navController.isInitialized) {
           val previousEntry = navController.previousBackStackEntry
           TSLog.d("MainActivity", "onNewIntent: previousBackStackEntry = $previousEntry")
-
           if (previousEntry != null) {
             navController.popBackStack(route = "main", inclusive = false)
           } else {
@@ -478,7 +504,6 @@ class MainActivity : ComponentActivity() {
                   putExtra(START_AT_ROOT, true)
                 }
             startActivity(intent)
-
             // Cancel coroutine once we've logged in
             this@launch.cancel()
           }
@@ -487,7 +512,6 @@ class MainActivity : ComponentActivity() {
         TSLog.e(TAG, "Login: failed to start MainActivity: $e")
       }
     }
-
     val url = urlString.toUri()
     try {
       val customTabsIntent = CustomTabsIntent.Builder().build()

--- a/android/src/main/java/com/tailscale/ipn/TaildropDirectoryStore.kt
+++ b/android/src/main/java/com/tailscale/ipn/TaildropDirectoryStore.kt
@@ -16,14 +16,6 @@ object TaildropDirectoryStore {
   fun saveFileDirectory(directoryUri: Uri) {
     val prefs = App.get().getEncryptedPrefs()
     prefs.edit().putString(PREF_KEY_SAF_URI, directoryUri.toString()).commit()
-    try {
-      // Must restart Tailscale because a new LocalBackend with the new directory must be created.
-      App.get().startLibtailscale(directoryUri.toString())
-    } catch (e: Exception) {
-      TSLog.d(
-          "TaildropDirectoryStore",
-          "saveFileDirectory: Failed to restart Libtailscale with the new directory: $e")
-    }
   }
 
   @Throws(IOException::class, GeneralSecurityException::class)

--- a/android/src/main/java/com/tailscale/ipn/ui/view/SettingsView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/SettingsView.kt
@@ -40,13 +40,13 @@ import com.tailscale.ipn.ui.util.Lists
 import com.tailscale.ipn.ui.util.set
 import com.tailscale.ipn.ui.viewModel.SettingsNav
 import com.tailscale.ipn.ui.viewModel.SettingsViewModel
-import com.tailscale.ipn.ui.viewModel.VpnViewModel
+import com.tailscale.ipn.ui.viewModel.AppViewModel
 
 @Composable
 fun SettingsView(
     settingsNav: SettingsNav,
     viewModel: SettingsViewModel = viewModel(),
-    vpnViewModel: VpnViewModel = viewModel()
+    appViewModel: AppViewModel = viewModel()
 ) {
   val handler = LocalUriHandler.current
 
@@ -55,7 +55,7 @@ fun SettingsView(
   val managedByOrganization by viewModel.managedByOrganization.collectAsState()
   val tailnetLockEnabled by viewModel.tailNetLockEnabled.collectAsState()
   val corpDNSEnabled by viewModel.corpDNSEnabled.collectAsState()
-  val isVPNPrepared by vpnViewModel.vpnPrepared.collectAsState()
+  val isVPNPrepared by appViewModel.vpnPrepared.collectAsState()
   val showTailnetLock by MDMSettings.manageTailnetLock.flow.collectAsState()
   val useTailscaleSubnets by MDMSettings.useTailscaleSubnets.flow.collectAsState()
 

--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/AppViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/AppViewModel.kt
@@ -1,0 +1,119 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package com.tailscale.ipn.ui.viewModel
+
+import android.app.Application
+import android.net.Uri
+import android.net.VpnService
+import android.util.Log
+import androidx.activity.result.ActivityResultLauncher
+import androidx.documentfile.provider.DocumentFile
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.tailscale.ipn.App
+import com.tailscale.ipn.util.ShareFileHelper
+import com.tailscale.ipn.util.TSLog
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class AppViewModelFactory(val application: Application, private val taildropPrompt: Flow<Unit>) :
+    ViewModelProvider.Factory {
+  @Suppress("UNCHECKED_CAST")
+  override fun <T : ViewModel> create(modelClass: Class<T>): T {
+    if (modelClass.isAssignableFrom(AppViewModel::class.java)) {
+      return AppViewModel(application, taildropPrompt) as T
+    }
+    throw IllegalArgumentException("Unknown ViewModel class")
+  }
+}
+
+// Application context-aware ViewModel used to track app-wide VPN and Taildrop state.
+// This must be application-scoped because Tailscale may be enabled, disabled, or used for
+// file transfers (Taildrop) outside the activity lifecycle.
+//
+// Responsibilities:
+// - Track VPN preparation state (e.g., whether permission has been granted) and activity state
+// - Monitor incoming Taildrop file transfers
+// - Coordinate prompts for Taildrop directory selection if not yet configured
+class AppViewModel(application: Application, private val taildropPrompt: Flow<Unit>) :
+    AndroidViewModel(application) {
+  // Whether the VPN is prepared. This is set to true if the VPN application is already prepared, or
+  // if the user has previously consented to the VPN application. This is used to determine whether
+  // a VPN permission launcher needs to be shown.
+  val _vpnPrepared = MutableStateFlow(false)
+  val vpnPrepared: StateFlow<Boolean> = _vpnPrepared
+  // Whether a VPN interface has been established. This is set by net.updateTUN upon
+  // VpnServiceBuilder.establish, and consumed by UI to reflect VPN state.
+  val _vpnActive = MutableStateFlow(false)
+  val vpnActive: StateFlow<Boolean> = _vpnActive
+  // Select Taildrop directory
+  var directoryPickerLauncher: ActivityResultLauncher<Uri?>? = null
+  private val _triggerDirectoryPicker = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+  val triggerDirectoryPicker: SharedFlow<Unit> = _triggerDirectoryPicker
+  val TAG = "AppViewModel"
+
+  init {
+    observeIncomingTaildrop()
+    prepareVpn()
+  }
+
+  private fun observeIncomingTaildrop() {
+    viewModelScope.launch {
+      taildropPrompt.collect {
+        TSLog.d(TAG, "Taildrop event received, checking directory")
+        checkIfTaildropDirectorySelected()
+      }
+    }
+  }
+
+  fun requestDirectoryPicker() {
+    _triggerDirectoryPicker.tryEmit(Unit)
+  }
+
+  private fun prepareVpn() {
+    // Check if the user has granted permission yet.
+    if (!vpnPrepared.value) {
+      val vpnIntent = VpnService.prepare(getApplication())
+      if (vpnIntent != null) {
+        setVpnPrepared(false)
+        Log.d(TAG, "VpnService.prepare returned non-null intent")
+      } else {
+        setVpnPrepared(true)
+        Log.d(TAG, "VpnService.prepare returned null intent, VPN is already prepared")
+      }
+    }
+  }
+
+  fun checkIfTaildropDirectorySelected() {
+    val app = App.get()
+    val storedUri = app.getStoredDirectoryUri()
+    if (ShareFileHelper.hasValidTaildropDir()) {
+      return
+    }
+
+    val documentFile = storedUri?.let { DocumentFile.fromTreeUri(app, it) }
+    if (documentFile == null || !documentFile.exists() || !documentFile.canWrite()) {
+      TSLog.d(
+          "MainViewModel",
+          "Stored directory URI is invalid or inaccessible; launching directory picker.")
+      viewModelScope.launch { requestDirectoryPicker() }
+    } else {
+      TSLog.d("MainViewModel", "Using stored directory URI: $storedUri")
+    }
+  }
+
+  fun setVpnActive(isActive: Boolean) {
+    _vpnActive.value = isActive
+  }
+
+  fun setVpnPrepared(isPrepared: Boolean) {
+    _vpnPrepared.value = isPrepared
+  }
+}

--- a/android/src/main/java/com/tailscale/ipn/util/ShareFileHelper.kt
+++ b/android/src/main/java/com/tailscale/ipn/util/ShareFileHelper.kt
@@ -1,15 +1,20 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
-
 package com.tailscale.ipn.util
-
 import android.content.Context
 import android.net.Uri
 import android.os.ParcelFileDescriptor
 import android.provider.DocumentsContract
 import androidx.documentfile.provider.DocumentFile
+import com.tailscale.ipn.TaildropDirectoryStore
 import com.tailscale.ipn.ui.util.InputStreamAdapter
 import com.tailscale.ipn.ui.util.OutputStreamAdapter
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import libtailscale.Libtailscale
 import org.json.JSONObject
 import java.io.FileOutputStream
@@ -17,38 +22,80 @@ import java.io.IOException
 import java.io.OutputStream
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
-
 data class SafFile(val fd: Int, val uri: String)
 
 object ShareFileHelper : libtailscale.ShareFileHelper {
   private var appContext: Context? = null
+  private var app: libtailscale.Application? = null
   private var savedUri: String? = null
+  private var scope: CoroutineScope? = null
 
   @JvmStatic
-  fun init(context: Context, uri: String) {
+  fun init(context: Context, app: libtailscale.Application, uri: String, appScope: CoroutineScope) {
     appContext = context.applicationContext
+    this.app = app
     savedUri = uri
+    scope = appScope
     Libtailscale.setShareFileHelper(this)
+    TSLog.d("ShareFileHelper", "init ShareFileHelper with savedUri: $savedUri")
   }
 
   // A simple data class that holds a SAF OutputStream along with its URI.
   data class SafStream(val uri: String, val stream: OutputStream)
+
+  val taildropPrompt = MutableSharedFlow<Unit>(replay = 1)
+
+  fun observeTaildropPrompt(): Flow<Unit> = taildropPrompt
+
+  @Volatile private var directoryReady: CompletableDeferred<Unit>? = null
+
+  fun hasValidTaildropDir(): Boolean {
+    val uri = TaildropDirectoryStore.loadSavedDir()
+    if (uri == null) return false
+
+    // Only SAF tree URIs are supported
+    if (uri.scheme != "content") {
+      TSLog.w("ShareFileHelper", "Invalid URI scheme for taildrop dir: ${uri.scheme}")
+      return false
+    }
+
+    val context = appContext ?: return false
+    val docFile = DocumentFile.fromTreeUri(context, uri)
+
+    if (docFile == null || !docFile.exists() || !docFile.canWrite()) {
+      TSLog.w("ShareFileHelper", "Stored taildrop URI is invalid or inaccessible: $uri")
+      return false
+    }
+
+    return true
+  }
+
+  private suspend fun waitUntilTaildropDirReady() {
+    if (!hasValidTaildropDir()) {
+      if (directoryReady?.isActive != true) {
+        directoryReady = CompletableDeferred()
+        scope?.launch { taildropPrompt.emit(Unit) }
+      }
+      directoryReady?.await()
+    }
+  }
+
+  fun notifyDirectoryReady() {
+    directoryReady?.takeIf { !it.isCompleted }?.complete(Unit)
+  }
 
   // A helper function that opens or creates a SafStream for a given file.
   private fun openSafFileOutputStream(fileName: String): Pair<String, OutputStream?> {
     val context = appContext ?: return "" to null
     val dirUri = savedUri ?: return "" to null
     val dir = DocumentFile.fromTreeUri(context, Uri.parse(dirUri)) ?: return "" to null
-
     val file =
         dir.findFile(fileName)
             ?: dir.createFile("application/octet-stream", fileName)
             ?: return "" to null
-
     val os = context.contentResolver.openOutputStream(file.uri, "rw")
     return file.uri.toString() to os
   }
-
   @Throws(IOException::class)
   private fun openWriterFD(fileName: String, offset: Long): Pair<String, SeekableOutputStream> {
     val ctx = appContext ?: throw IOException("App context not initialized")
@@ -60,20 +107,18 @@ object ShareFileHelper : libtailscale.ShareFileHelper {
         dir.findFile(fileName)
             ?: dir.createFile("application/octet-stream", fileName)
             ?: throw IOException("Failed to create file: $fileName")
-
     val pfd =
         ctx.contentResolver.openFileDescriptor(file.uri, "rw")
             ?: throw IOException("Failed to open file descriptor for ${file.uri}")
     val fos = FileOutputStream(pfd.fileDescriptor)
-
     if (offset != 0L) fos.channel.position(offset) else fos.channel.truncate(0)
     return file.uri.toString() to SeekableOutputStream(fos, pfd)
   }
-
   private val currentUri = ConcurrentHashMap<String, String>()
 
   @Throws(IOException::class)
   override fun openFileWriter(fileName: String, offset: Long): libtailscale.OutputStream {
+    runBlocking { waitUntilTaildropDirReady() }
     val (uri, stream) = openWriterFD(fileName, offset)
     if (stream == null) {
       throw IOException("Failed to open file writer for $fileName")
@@ -84,22 +129,20 @@ object ShareFileHelper : libtailscale.ShareFileHelper {
 
   @Throws(IOException::class)
   override fun getFileURI(fileName: String): String {
+    runBlocking { waitUntilTaildropDirReady() }
     currentUri[fileName]?.let {
       return it
     }
-
     val ctx = appContext ?: throw IOException("App context not initialized")
     val dirStr = savedUri ?: throw IOException("No saved directory URI")
     val dir =
         DocumentFile.fromTreeUri(ctx, Uri.parse(dirStr))
             ?: throw IOException("Invalid tree URI: $dirStr")
-
     val file = dir.findFile(fileName) ?: throw IOException("File not found: $fileName")
     val uri = file.uri.toString()
     currentUri[fileName] = uri
     return uri
   }
-
   @Throws(IOException::class)
   override fun renameFile(oldPath: String, targetName: String): String {
     val ctx = appContext ?: throw IOException("not initialized")
@@ -108,7 +151,7 @@ object ShareFileHelper : libtailscale.ShareFileHelper {
     val dir =
         DocumentFile.fromTreeUri(ctx, Uri.parse(dirUri))
             ?: throw IOException("cannot open dir $dirUri")
-  
+
     var finalName = targetName
     dir.findFile(finalName)?.let { existing ->
       if (lengthOfUri(ctx, existing.uri) == 0L) {
@@ -117,7 +160,7 @@ object ShareFileHelper : libtailscale.ShareFileHelper {
         finalName = generateNewFilename(finalName)
       }
     }
-  
+
     try {
       DocumentsContract.renameDocument(ctx.contentResolver, srcUri, finalName)?.also { newUri ->
         runCatching { ctx.contentResolver.delete(srcUri, null, null) }
@@ -125,14 +168,14 @@ object ShareFileHelper : libtailscale.ShareFileHelper {
         return newUri.toString()
       }
     } catch (e: Exception) {
-      TSLog.w("renameFile", "renameDocument fallback triggered for $srcUri -> $finalName: ${e.message}")
-
+      TSLog.w(
+          "renameFile", "renameDocument fallback triggered for $srcUri -> $finalName: ${e.message}")
     }
-  
+
     val dest =
         dir.createFile("application/octet-stream", finalName)
             ?: throw IOException("createFile failed for $finalName")
-  
+
     ctx.contentResolver.openInputStream(srcUri).use { inp ->
       ctx.contentResolver.openOutputStream(dest.uri, "w").use { out ->
         if (inp == null || out == null) {
@@ -142,15 +185,13 @@ object ShareFileHelper : libtailscale.ShareFileHelper {
         inp.copyTo(out)
       }
     }
-  
+
     ctx.contentResolver.delete(srcUri, null, null)
     cleanupPartials(dir, targetName)
     return dest.uri.toString()
   }
-
   private fun lengthOfUri(ctx: Context, uri: Uri): Long =
       ctx.contentResolver.openAssetFileDescriptor(uri, "r").use { it?.length ?: -1 }
-
   // delete any stray “.partial” files for this base name
   private fun cleanupPartials(dir: DocumentFile, base: String) {
     for (child in dir.listFiles()) {
@@ -160,21 +201,18 @@ object ShareFileHelper : libtailscale.ShareFileHelper {
       }
     }
   }
-
   @Throws(IOException::class)
   override fun deleteFile(uri: String) {
+    runBlocking { waitUntilTaildropDirReady() }
     val ctx = appContext ?: throw IOException("DeleteFile: not initialized")
-
     val uri = Uri.parse(uri)
     val doc =
         DocumentFile.fromSingleUri(ctx, uri)
             ?: throw IOException("DeleteFile: cannot resolve URI $uri")
-
     if (!doc.delete()) {
       throw IOException("DeleteFile: delete() returned false for $uri")
     }
   }
-
   @Throws(IOException::class)
   override fun getFileInfo(fileName: String): String {
     val context = appContext ?: throw IOException("app context not initialized")
@@ -182,41 +220,32 @@ object ShareFileHelper : libtailscale.ShareFileHelper {
     val dir =
         DocumentFile.fromTreeUri(context, Uri.parse(dirUri))
             ?: throw IOException("could not resolve SAF root")
-
     val file =
         dir.findFile(fileName) ?: throw IOException("file \"$fileName\" not found in SAF directory")
-
     val name = file.name ?: throw IOException("file name missing for $fileName")
     val size = file.length()
     val modTime = file.lastModified()
-
     return """{"name":${JSONObject.quote(name)},"size":$size,"modTime":$modTime}"""
   }
-
   private fun jsonEscape(s: String): String {
     return JSONObject.quote(s)
   }
-
   fun generateNewFilename(filename: String): String {
     val dotIndex = filename.lastIndexOf('.')
     val baseName = if (dotIndex != -1) filename.substring(0, dotIndex) else filename
     val extension = if (dotIndex != -1) filename.substring(dotIndex) else ""
-
     val uuid = UUID.randomUUID()
     return "$baseName-$uuid$extension"
   }
-
   fun listPartialFiles(suffix: String): Array<String> {
     val context = appContext ?: return emptyArray()
     val rootUri = savedUri ?: return emptyArray()
     val dir = DocumentFile.fromTreeUri(context, Uri.parse(rootUri)) ?: return emptyArray()
-
     return dir.listFiles()
         .filter { it.name?.endsWith(suffix) == true }
         .mapNotNull { it.name }
         .toTypedArray()
   }
-
   @Throws(IOException::class)
   override fun listFilesJSON(suffix: String): String {
     val list = listPartialFiles(suffix)
@@ -225,7 +254,6 @@ object ShareFileHelper : libtailscale.ShareFileHelper {
     }
     return list.joinToString(prefix = "[\"", separator = "\",\"", postfix = "\"]")
   }
-
   @Throws(IOException::class)
   override fun openFileReader(name: String): libtailscale.InputStream {
     val context = appContext ?: throw IOException("app context not initialized")
@@ -233,37 +261,32 @@ object ShareFileHelper : libtailscale.ShareFileHelper {
     val dir =
         DocumentFile.fromTreeUri(context, Uri.parse(rootUri))
             ?: throw IOException("could not open SAF root")
-
     val suffix = name.substringAfterLast('.', ".$name")
-
     val file =
         dir.listFiles().firstOrNull {
           val fname = it.name ?: return@firstOrNull false
           fname.endsWith(suffix, ignoreCase = false)
         } ?: throw IOException("no file ending with \"$suffix\" in SAF directory")
-
     val inStream =
         context.contentResolver.openInputStream(file.uri)
             ?: throw IOException("openInputStream returned null for ${file.uri}")
-
     return InputStreamAdapter(inStream)
+  }
+
+  fun setUri(uri: String) {
+    savedUri = uri
   }
 
   private class SeekableOutputStream(
       private val fos: FileOutputStream,
       private val pfd: ParcelFileDescriptor
   ) : OutputStream() {
-
     private var closed = false
-
     override fun write(b: Int) = fos.write(b)
-
     override fun write(b: ByteArray) = fos.write(b)
-
     override fun write(b: ByteArray, off: Int, len: Int) {
       fos.write(b, off, len)
     }
-
     override fun close() {
       if (!closed) {
         closed = true
@@ -276,7 +299,6 @@ object ShareFileHelper : libtailscale.ShareFileHelper {
         }
       }
     }
-
     override fun flush() = fos.flush()
   }
 }

--- a/libtailscale/backend.go
+++ b/libtailscale/backend.go
@@ -58,8 +58,6 @@ type App struct {
 	backend         *ipnlocal.LocalBackend
 	ready           sync.WaitGroup
 	backendMu       sync.Mutex
-
-	backendRestartCh chan struct{}
 }
 
 func start(dataDir, directFileRoot string, appCtx AppContext) Application {
@@ -114,23 +112,6 @@ type backend struct {
 type settingsFunc func(*router.Config, *dns.OSConfig) error
 
 func (a *App) runBackend(ctx context.Context) error {
-	for {
-		err := a.runBackendOnce(ctx)
-		if err != nil {
-			log.Printf("runBackendOnce error: %v", err)
-		}
-
-		// Wait for a restart trigger
-		<-a.backendRestartCh
-	}
-}
-
-func (a *App) runBackendOnce(ctx context.Context) error {
-	select {
-	case <-a.backendRestartCh:
-	default:
-	}
-
 	paths.AppSharedDir.Store(a.dataDir)
 	hostinfo.SetOSVersion(a.osVersion())
 	hostinfo.SetPackage(a.appCtx.GetInstallSource())
@@ -338,7 +319,6 @@ func (a *App) newBackend(dataDir string, appCtx AppContext, store *stateStore,
 	lb, err := ipnlocal.NewLocalBackend(logf, logID.Public(), sys, 0)
 	if ext, ok := ipnlocal.GetExt[*taildrop.Extension](lb); ok {
 		ext.SetFileOps(newAndroidFileOps(a.shareFileHelper))
-		ext.SetDirectFileRoot(a.directFileRoot)
 	}
 
 	if err != nil {
@@ -368,14 +348,9 @@ func (a *App) newBackend(dataDir string, appCtx AppContext, store *stateStore,
 func (a *App) watchFileOpsChanges() {
 	for {
 		select {
-		case newPath := <-onFilePath:
-			log.Printf("Got new directFileRoot")
-			a.directFileRoot = newPath
-			a.backendRestartCh <- struct{}{}
 		case helper := <-onShareFileHelper:
-			log.Printf("Got shareFIleHelper")
+			log.Printf("Got ShareFileHelper")
 			a.shareFileHelper = helper
-			a.backendRestartCh <- struct{}{}
 		}
 	}
 }

--- a/libtailscale/callbacks.go
+++ b/libtailscale/callbacks.go
@@ -26,9 +26,6 @@ var (
 
 	// onShareFileHelper receives ShareFileHelper references when the app is initialized so that files can be received via Storage Access Framework
 	onShareFileHelper = make(chan ShareFileHelper, 1)
-
-	// onFilePath receives the SAF path used for Taildrop
-	onFilePath = make(chan string)
 )
 
 // ifname is the interface name retrieved from LinkProperties on network change. An empty string is used if there is no network available.

--- a/libtailscale/interfaces.go
+++ b/libtailscale/interfaces.go
@@ -243,7 +243,3 @@ func SetShareFileHelper(fileHelper ShareFileHelper) {
 		onShareFileHelper <- fileHelper
 	}
 }
-
-func SetDirectFileRoot(filePath string) {
-	onFilePath <- filePath
-}

--- a/libtailscale/tailscale.go
+++ b/libtailscale/tailscale.go
@@ -32,10 +32,9 @@ const (
 
 func newApp(dataDir, directFileRoot string, appCtx AppContext) Application {
 	a := &App{
-		directFileRoot:   directFileRoot,
-		dataDir:          dataDir,
-		appCtx:           appCtx,
-		backendRestartCh: make(chan struct{}, 1),
+		directFileRoot: directFileRoot,
+		dataDir:        dataDir,
+		appCtx:         appCtx,
 	}
 	a.ready.Add(2)
 


### PR DESCRIPTION
Move Taildrop directory selector out of onboarding -Listen for Taildrop, and show selector if a directory has not been set

Remove LocalBackend re-initialization
-This is no longer necessary since the directory is set in FileOps

Updates tailscale/corp#29211


(cherry picked from commit e68e64014ea0f9ee4ccc11d042119e0413accf5b)