### PR TITLE
android: Taildrop/share plain text (i.e. clipboard)

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -131,6 +131,16 @@
                 android:value="true" />
         </service>
 
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="com.tailscale.ipn.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
+
         <meta-data
             android:name="android.content.APP_RESTRICTIONS"
             android:resource="@xml/app_restrictions" />

--- a/android/src/main/java/com/tailscale/ipn/ShareActivity.kt
+++ b/android/src/main/java/com/tailscale/ipn/ShareActivity.kt
@@ -3,6 +3,7 @@
 
 package com.tailscale.ipn
 
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
@@ -14,6 +15,7 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
+import androidx.core.content.FileProvider
 import androidx.lifecycle.lifecycleScope
 import com.tailscale.ipn.ui.model.Ipn
 import com.tailscale.ipn.ui.theme.AppTheme
@@ -27,6 +29,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.io.File
 
 // ShareActivity is the entry point for Taildrop share intents
 class ShareActivity : ComponentActivity() {
@@ -57,11 +60,13 @@ class ShareActivity : ComponentActivity() {
   override fun onNewIntent(intent: Intent) {
     super.onNewIntent(intent)
     setIntent(intent)
-    loadFiles()
+    lifecycleScope.launch {
+      loadFiles()
+    }
   }
 
   // Loads the files from the intent.
-  fun loadFiles() {
+  suspend fun loadFiles() {
     if (intent == null) {
       TSLog.e(TAG, "Share failure - No intent found")
       return
@@ -75,6 +80,13 @@ class ShareActivity : ComponentActivity() {
             if (intent.extras?.containsKey(Intent.EXTRA_STREAM) == true) {
               // If EXTRA_STREAM is present, get the single URI for that stream
               listOfNotNull(intent.versionSafeGetStreamUri())
+            }
+            else if (intent.extras?.containsKey(Intent.EXTRA_TEXT) == true) {
+              // If EXTRA_TEXT is present, create a temporary file with the text content.
+              // This could be any shared text, like a URL or plain text from the clipboard.
+              val text = intent.getStringExtra(Intent.EXTRA_TEXT) ?: ""
+              val uri = createTemporaryFile(text)
+              listOf(uri)
             }
             else {
               TSLog.e(TAG, "No extras found in intent - nothing to share")
@@ -141,3 +153,35 @@ private fun Intent.versionSafeGetStreamUris(): List<Uri> =
   }
     ?.filterNotNull()
     ?: emptyList()
+
+/**
+ * Creates a temporary txt file in the app's cache directory with the given content.
+ * Then grants temporary read permission to the file using FileProvider and returns its URI.
+ */
+private suspend fun Context.createTemporaryFile(
+  content: String,
+  dir: File = cacheDir,
+  fileName: String = "shared_text_${System.currentTimeMillis()}.txt",
+): Uri {
+  // Create temporary file in cache directory
+  val tempFile = File(dir, fileName)
+  withContext(Dispatchers.IO) {
+    tempFile.writeText(content)
+  }
+
+  // Get content URI using FileProvider
+  val uri = FileProvider.getUriForFile(
+    this,
+    "${applicationContext.packageName}.fileprovider",
+    tempFile
+  )
+
+  // Grant temporary read permission
+  grantUriPermission(
+    packageName,
+    uri,
+    Intent.FLAG_GRANT_READ_URI_PERMISSION
+  )
+
+  return uri
+}

--- a/android/src/main/res/xml/file_paths.xml
+++ b/android/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path name="shared" path="/" />
+</paths>


### PR DESCRIPTION
Fixes tailscale/tailscale#16850

This enables the ability to share text (Taildrop) from Android, via the clipboard or any other text sharing intent. The relevant intent is already handled by the app, but plain text is just ignored.

This is a partial solution to [my request here](https://androiddev.social/@dgmltn/115012145641445538)

<img width="3157" height="1757" alt="image" src="https://github.com/user-attachments/assets/94545624-d138-4125-a275-64d7e1b2b1c5" />

An open question: what do you think of the generated filename `shared_text_[epoch].txt`? I see the existing fallback filename when the filename is unknown is simply `[epoch].txt` but it seemed appropriate to add a bit of context when it's known that the text is coming from a share intent instead of directly from a file on disk.
