### PR TITLE
android: bump OSS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.1
 require (
 	github.com/tailscale/wireguard-go v0.0.0-20250716170648-1d0488a3d7da
 	golang.org/x/mobile v0.0.0-20240806205939-81131f6468ab
-	tailscale.com v1.89.0-pre.0.20250930191317-9386a101d885
+	tailscale.com v1.89.0-pre.0.20251007234322-ad6cf2f8f369
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -235,5 +235,5 @@ howett.net/plist v1.0.0 h1:7CrbWYbPPO/PyNy38b2EB/+gYbjCe2DXBxgtOOZbSQM=
 howett.net/plist v1.0.0/go.mod h1:lqaXoTrLY4hg8tnEzNru53gicrbv7rrk+2xJA/7hw9g=
 software.sslmate.com/src/go-pkcs12 v0.4.0 h1:H2g08FrTvSFKUj+D309j1DPfk5APnIdAQAB8aEykJ5k=
 software.sslmate.com/src/go-pkcs12 v0.4.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=
-tailscale.com v1.89.0-pre.0.20250930191317-9386a101d885 h1:6q+2szaZyuooFtOIztf7z0RGPlTXBYhbY634FYkzLPM=
-tailscale.com v1.89.0-pre.0.20250930191317-9386a101d885/go.mod h1:LHaTiwRgzebPDLgZ6RQQVzX+1SR5fbNl51fzm7UtMaw=
+tailscale.com v1.89.0-pre.0.20251007234322-ad6cf2f8f369 h1:R0qM9p0onHXFzkk4TupOUrCsEoe0ruxLQ2nqpgHw/hQ=
+tailscale.com v1.89.0-pre.0.20251007234322-ad6cf2f8f369/go.mod h1:guEE7f/DUsP+KD5MpqN6dmtQOYoq8JMR7zh2mse3cq8=


### PR DESCRIPTION
OSS and Version updated to 1.89.219-tad6cf2f8f-g7e3da8a35

Updates tailscale/tailscale#17363

--

Stacked on #708