### PR TITLE
Feature/auto vpn

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"

--- a/android/src/main/java/com/tailscale/ipn/App.kt
+++ b/android/src/main/java/com/tailscale/ipn/App.kt
@@ -25,6 +25,7 @@ import androidx.lifecycle.ViewModelStore
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
+import com.tailscale.ipn.autoconnect.NetworkWatcher
 import com.tailscale.ipn.mdm.MDMSettings
 import com.tailscale.ipn.mdm.MDMSettingsChangedReceiver
 import com.tailscale.ipn.ui.localapi.Client
@@ -88,6 +89,8 @@ class App : UninitializedApp(), libtailscale.AppContext, ViewModelStoreOwner {
 
   private val appViewModelStore: ViewModelStore by lazy { ViewModelStore() }
   var healthNotifier: HealthNotifier? = null
+  lateinit var networkWatcher: NetworkWatcher
+    private set
 
   override fun getPlatformDNSConfig(): String = dns.dnsConfigAsString
 
@@ -128,10 +131,14 @@ class App : UninitializedApp(), libtailscale.AppContext, ViewModelStoreOwner {
         getString(R.string.health_channel_name),
         getString(R.string.health_channel_description),
         NotificationManagerCompat.IMPORTANCE_HIGH)
+
+    networkWatcher = NetworkWatcher(this)
+    networkWatcher.register()
   }
 
   override fun onTerminate() {
     super.onTerminate()
+    networkWatcher.unregister()
     Notifier.stop()
     notificationManager.cancelAll()
     applicationScope.cancel()

--- a/android/src/main/java/com/tailscale/ipn/MainActivity.kt
+++ b/android/src/main/java/com/tailscale/ipn/MainActivity.kt
@@ -92,6 +92,7 @@ import com.tailscale.ipn.ui.view.SubnetRoutingView
 import com.tailscale.ipn.ui.view.TaildropDirView
 import com.tailscale.ipn.ui.view.TaildropDirectoryPickerPrompt
 import com.tailscale.ipn.ui.view.TailnetLockSetupView
+import com.tailscale.ipn.ui.view.TrustedNetworksView
 import com.tailscale.ipn.ui.view.UserSwitcherNav
 import com.tailscale.ipn.ui.view.UserSwitcherView
 import com.tailscale.ipn.ui.viewModel.AppViewModel
@@ -310,6 +311,9 @@ class MainActivity : ComponentActivity() {
                           onNavigateToManagedBy = { navController.navigate("managedBy") },
                           onNavigateToUserSwitcher = { navController.navigate("userSwitcher") },
                           onNavigateToPermissions = { navController.navigate("permissions") },
+                          onNavigateToTrustedNetworks = {
+                            navController.navigate("trustedNetworks")
+                          },
                           onBackToSettings = backTo("settings"),
                           onNavigateBackHome = backTo("main"))
                   val exitNodePickerNav =
@@ -375,6 +379,9 @@ class MainActivity : ComponentActivity() {
                   composable("splitTunneling") { SplitTunnelAppPickerView(backTo("settings")) }
                   composable("tailnetLock") { TailnetLockSetupView(backTo("settings")) }
                   composable("subnetRouting") { SubnetRoutingView(backTo("settings")) }
+                  composable("trustedNetworks") {
+                    TrustedNetworksView(onNavigateBack = backTo("settings"))
+                  }
                   composable("about") { AboutView(backTo("settings")) }
                   composable("mdmSettings") { MDMSettingsDebugView(backTo("settings")) }
                   composable("managedBy") { ManagedByView(backTo("settings")) }

--- a/android/src/main/java/com/tailscale/ipn/autoconnect/NetworkWatcher.kt
+++ b/android/src/main/java/com/tailscale/ipn/autoconnect/NetworkWatcher.kt
@@ -1,0 +1,201 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package com.tailscale.ipn.autoconnect
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import android.net.wifi.WifiInfo
+import android.net.wifi.WifiManager
+import android.os.Handler
+import android.os.Looper
+import com.tailscale.ipn.App
+import com.tailscale.ipn.ui.model.Ipn
+import com.tailscale.ipn.ui.notifier.Notifier
+import com.tailscale.ipn.util.TSLog
+
+class NetworkWatcher(private val context: Context) {
+
+  private val cm =
+      context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+  private var registered = false
+  private val handler = Handler(Looper.getMainLooper())
+  private var pendingEvaluation: Runnable? = null
+  private var lastAction: String? = null
+  private var ssidRetryCount = 0
+
+  fun register() {
+    if (registered) return
+    val request =
+        NetworkRequest.Builder()
+            .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+            .addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR)
+            .build()
+    cm.registerNetworkCallback(request, callback)
+    registered = true
+    evaluateCurrent()
+  }
+
+  fun unregister() {
+    if (!registered) return
+    cm.unregisterNetworkCallback(callback)
+    registered = false
+  }
+
+  private fun scheduleEvaluation() {
+    pendingEvaluation?.let { handler.removeCallbacks(it) }
+    val runnable = Runnable { evaluateCurrent() }
+    pendingEvaluation = runnable
+    handler.postDelayed(runnable, DEBOUNCE_MS)
+  }
+
+  private val callback =
+      object : ConnectivityManager.NetworkCallback() {
+
+        override fun onCapabilitiesChanged(
+            network: Network,
+            caps: NetworkCapabilities
+        ) {
+          if (!TrustedNetworks.isEnabled(context)) return
+          // Ignore VPN network changes — they are created by us
+          if (caps.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) return
+          scheduleEvaluation()
+        }
+
+        override fun onLost(network: Network) {
+          if (!TrustedNetworks.isEnabled(context)) return
+          scheduleEvaluation()
+        }
+      }
+
+  private fun getSsid(caps: NetworkCapabilities): String? {
+    // Method 1: transportInfo from NetworkCapabilities
+    var ssid =
+        (caps.transportInfo as? WifiInfo)?.ssid?.trim('"')
+            ?.takeIf { it.isNotBlank() && it != "<unknown ssid>" }
+    if (ssid != null) {
+      TSLog.d(TAG, "SSID from transportInfo: $ssid")
+      return ssid
+    }
+
+    // Method 2: WifiManager.connectionInfo (deprecated but works on some Android 12+ devices)
+    val wm = context.getSystemService(Context.WIFI_SERVICE) as WifiManager
+    @Suppress("DEPRECATION")
+    ssid = wm.connectionInfo?.ssid?.trim('"')
+        ?.takeIf { it.isNotBlank() && it != "<unknown ssid>" }
+    if (ssid != null) {
+      TSLog.d(TAG, "SSID from WifiManager: $ssid")
+      return ssid
+    }
+
+    // Method 3: WifiManager.scanResults — match by BSSID from connectionInfo
+    @Suppress("DEPRECATION")
+    val bssid = wm.connectionInfo?.bssid
+    if (bssid != null) {
+      ssid = wm.scanResults
+          ?.firstOrNull { it.BSSID == bssid }
+          ?.SSID
+          ?.trim('"')
+          ?.takeIf { it.isNotBlank() }
+      if (ssid != null) {
+        TSLog.d(TAG, "SSID from scanResults: $ssid")
+        return ssid
+      }
+    }
+
+    TSLog.d(TAG, "Could not determine SSID")
+    return null
+  }
+
+  private fun handleWifi(caps: NetworkCapabilities) {
+    val ssid = getSsid(caps)
+
+    if (ssid == null) {
+      // SSID may not be available yet after Wi-Fi association — retry a few times
+      if (ssidRetryCount < MAX_SSID_RETRIES) {
+        ssidRetryCount++
+        TSLog.d(TAG, "SSID null on Wi-Fi, scheduling retry $ssidRetryCount/$MAX_SSID_RETRIES")
+        handler.postDelayed({ evaluateCurrent() }, SSID_RETRY_DELAY_MS)
+      }
+      return
+    }
+
+    ssidRetryCount = 0
+    val trusted = TrustedNetworks.load(context)
+    TSLog.d(TAG, "SSID='$ssid' trusted_list=$trusted match=${ssid in trusted}")
+    if (ssid in trusted) {
+      disableVpn()
+    } else {
+      enableVpn()
+    }
+  }
+
+  private fun enableVpn() {
+    if (lastAction == "enable") return
+    val state = Notifier.state.value
+    if (state == Ipn.State.Running) {
+      lastAction = "enable"
+      return
+    }
+    lastAction = "enable"
+    TSLog.d(TAG, "Enabling VPN (auto-vpn)")
+    App.get().startVPN()
+  }
+
+  private fun disableVpn() {
+    if (lastAction == "disable") return
+    val state = Notifier.state.value
+    if (state != Ipn.State.Running) {
+      lastAction = "disable"
+      return
+    }
+    lastAction = "disable"
+    TSLog.d(TAG, "Disabling VPN (trusted network)")
+    App.get().stopVPN()
+  }
+
+  fun reevaluate() {
+    lastAction = null
+    ssidRetryCount = 0
+    evaluateCurrent()
+  }
+
+  fun evaluateCurrent() {
+    if (!TrustedNetworks.isEnabled(context)) return
+
+    // Find the underlying Wi-Fi or cellular network, skipping VPN
+    var wifiCaps: NetworkCapabilities? = null
+    var hasCellular = false
+
+    for (network in cm.allNetworks) {
+      val caps = cm.getNetworkCapabilities(network) ?: continue
+      if (caps.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) continue
+      if (caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
+        wifiCaps = caps
+        break // Wi-Fi takes priority
+      }
+      if (caps.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) {
+        hasCellular = true
+      }
+    }
+
+    TSLog.d(TAG, "evaluateCurrent: wifi=${wifiCaps != null} cellular=$hasCellular")
+
+    when {
+      wifiCaps != null -> handleWifi(wifiCaps)
+      hasCellular -> enableVpn()
+      else -> enableVpn()
+    }
+  }
+
+  companion object {
+    private const val TAG = "NetworkWatcher"
+    private const val DEBOUNCE_MS = 2000L
+    private const val SSID_RETRY_DELAY_MS = 3000L
+    private const val MAX_SSID_RETRIES = 5
+  }
+}

--- a/android/src/main/java/com/tailscale/ipn/autoconnect/TrustedNetworks.kt
+++ b/android/src/main/java/com/tailscale/ipn/autoconnect/TrustedNetworks.kt
@@ -1,0 +1,36 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package com.tailscale.ipn.autoconnect
+
+import android.content.Context
+
+object TrustedNetworks {
+  private const val PREFS_NAME = "tailscale_auto"
+  private const val KEY_SSIDS = "trusted_ssids"
+  private const val KEY_ENABLED = "auto_vpn_enabled"
+
+  fun isEnabled(ctx: Context): Boolean =
+      ctx.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+          .getBoolean(KEY_ENABLED, false)
+
+  fun setEnabled(ctx: Context, enabled: Boolean) =
+      ctx.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+          .edit()
+          .putBoolean(KEY_ENABLED, enabled)
+          .apply()
+
+  fun load(ctx: Context): Set<String> =
+      ctx.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+          .getStringSet(KEY_SSIDS, emptySet()) ?: emptySet()
+
+  fun save(ctx: Context, ssids: Set<String>) =
+      ctx.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+          .edit()
+          .putStringSet(KEY_SSIDS, ssids)
+          .apply()
+
+  fun add(ctx: Context, ssid: String) = save(ctx, load(ctx) + ssid)
+
+  fun remove(ctx: Context, ssid: String) = save(ctx, load(ctx) - ssid)
+}

--- a/android/src/main/java/com/tailscale/ipn/ui/model/Permissions.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/model/Permissions.kt
@@ -79,6 +79,11 @@ object Permissions {
               R.string.permission_post_notifications,
               R.string.permission_post_notifications_needed))
     }
+    result.add(
+        Permission(
+            Manifest.permission.ACCESS_FINE_LOCATION,
+            R.string.permission_location,
+            R.string.permission_location_needed))
     result
   }
 }

--- a/android/src/main/java/com/tailscale/ipn/ui/view/SettingsView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/SettingsView.kt
@@ -111,6 +111,12 @@ fun SettingsView(
             Setting.Text(R.string.permissions, onClick = settingsNav.onNavigateToPermissions)
           }
 
+          Lists.ItemDivider()
+          Setting.Text(
+              R.string.auto_vpn,
+              subtitle = "Auto-toggle VPN based on network",
+              onClick = settingsNav.onNavigateToTrustedNetworks)
+
           managedByOrganization.value?.let {
             Lists.ItemDivider()
             Setting.Text(
@@ -219,5 +225,5 @@ fun SettingsPreview() {
   vm.tailNetLockEnabled.set(true)
   vm.isAdmin.set(true)
   vm.managedByOrganization.set("Tails and Scales Inc.")
-  SettingsView(SettingsNav({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}), vm)
+  SettingsView(SettingsNav({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}), vm)
 }

--- a/android/src/main/java/com/tailscale/ipn/ui/view/TrustedNetworksView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/TrustedNetworksView.kt
@@ -1,0 +1,218 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package com.tailscale.ipn.ui.view
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.tailscale.ipn.R
+import com.tailscale.ipn.ui.viewModel.TrustedNetworksViewModel
+
+@Composable
+fun TrustedNetworksView(
+    onNavigateBack: () -> Unit,
+    viewModel: TrustedNetworksViewModel = viewModel()
+) {
+  val enabled by viewModel.enabled.collectAsState()
+  val ssids by viewModel.trustedSsids.collectAsState()
+  val currentSsid by viewModel.currentSsid.collectAsState()
+  var manualInput by remember { mutableStateOf("") }
+
+  val context = LocalContext.current
+  var locationGranted by remember {
+    mutableStateOf(
+        ContextCompat.checkSelfPermission(
+            context, android.Manifest.permission.ACCESS_FINE_LOCATION) ==
+            android.content.pm.PackageManager.PERMISSION_GRANTED)
+  }
+  val permissionLauncher =
+      rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+        locationGranted = granted
+        if (granted) viewModel.refreshCurrentSsid()
+      }
+
+  LaunchedEffect(enabled) {
+    if (enabled && !locationGranted) {
+      permissionLauncher.launch(android.Manifest.permission.ACCESS_FINE_LOCATION)
+    }
+  }
+
+  Scaffold(topBar = { Header(titleRes = R.string.auto_vpn, onBack = onNavigateBack) }) {
+      innerPadding ->
+    Column(
+        modifier =
+            Modifier.fillMaxSize()
+                .padding(innerPadding)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState())) {
+          Text(
+              text =
+                  "When enabled, Tailscale VPN will be disabled on trusted Wi-Fi networks " +
+                      "and enabled automatically on untrusted Wi-Fi, cellular data, " +
+                      "or when no Wi-Fi is connected.",
+              style = MaterialTheme.typography.bodyMedium,
+              modifier = Modifier.padding(bottom = 16.dp))
+
+          // -- Feature toggle --
+          Row(
+              modifier = Modifier.fillMaxWidth(),
+              horizontalArrangement = Arrangement.SpaceBetween,
+              verticalAlignment = Alignment.CenterVertically) {
+                Text("Enable Auto-VPN", style = MaterialTheme.typography.titleMedium)
+                Switch(checked = enabled, onCheckedChange = { viewModel.setEnabled(it) })
+              }
+
+          Spacer(modifier = Modifier.height(24.dp))
+
+          if (!enabled) {
+            Text(
+                text = "Enable Auto-VPN above to configure trusted networks.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant)
+          } else {
+            if (!locationGranted) {
+              Text(
+                  text =
+                      "Location permission is required to detect the current Wi-Fi network. " +
+                          "Without it, VPN will stay enabled on all networks (fail-secure).",
+                  style = MaterialTheme.typography.bodySmall,
+                  color = MaterialTheme.colorScheme.error,
+                  modifier = Modifier.padding(bottom = 8.dp))
+              OutlinedButton(
+                  onClick = {
+                    permissionLauncher.launch(android.Manifest.permission.ACCESS_FINE_LOCATION)
+                  },
+                  modifier = Modifier.fillMaxWidth()) {
+                    Text("Grant location permission")
+                  }
+              Spacer(modifier = Modifier.height(16.dp))
+            }
+
+            // -- Current network shortcut --
+            currentSsid?.let { ssid ->
+              if (ssid !in ssids) {
+                OutlinedButton(
+                    onClick = { viewModel.addSsid(ssid) }, modifier = Modifier.fillMaxWidth()) {
+                      Icon(Icons.Default.Add, contentDescription = null)
+                      Spacer(modifier = Modifier.width(8.dp))
+                      Text("Trust current network: $ssid")
+                    }
+              } else {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                  Icon(
+                      Icons.Default.CheckCircle,
+                      contentDescription = null,
+                      tint = MaterialTheme.colorScheme.primary)
+                  Spacer(modifier = Modifier.width(8.dp))
+                  Text(
+                      text = "Current network is trusted: $ssid",
+                      color = MaterialTheme.colorScheme.primary)
+                }
+              }
+              Spacer(modifier = Modifier.height(16.dp))
+            }
+
+            // -- Manual SSID entry --
+            Text(
+                text = "Add a trusted network manually",
+                style = MaterialTheme.typography.titleSmall,
+                modifier = Modifier.padding(bottom = 4.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+              OutlinedTextField(
+                  value = manualInput,
+                  onValueChange = { manualInput = it },
+                  placeholder = { Text("Network SSID") },
+                  singleLine = true,
+                  modifier = Modifier.weight(1f))
+              Spacer(modifier = Modifier.width(8.dp))
+              IconButton(
+                  onClick = {
+                    val trimmed = manualInput.trim()
+                    if (trimmed.isNotBlank()) {
+                      viewModel.addSsid(trimmed)
+                      manualInput = ""
+                    }
+                  }) {
+                    Icon(Icons.Default.Add, contentDescription = "Add network")
+                  }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // -- Trusted network list --
+            Text(
+                text = "Trusted Networks",
+                style = MaterialTheme.typography.titleSmall,
+                modifier = Modifier.padding(bottom = 8.dp))
+
+            if (ssids.isEmpty()) {
+              Text(
+                  text = "No trusted networks yet. Add your home network above.",
+                  style = MaterialTheme.typography.bodyMedium,
+                  color = MaterialTheme.colorScheme.onSurfaceVariant)
+            } else {
+              ssids.sorted().forEach { ssid ->
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically) {
+                      Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            Icons.Default.CheckCircle,
+                            contentDescription = null,
+                            modifier = Modifier.size(20.dp))
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(ssid)
+                      }
+                      IconButton(onClick = { viewModel.removeSsid(ssid) }) {
+                        Icon(
+                            Icons.Default.Close,
+                            contentDescription = "Remove $ssid",
+                            tint = MaterialTheme.colorScheme.error)
+                      }
+                    }
+                HorizontalDivider()
+              }
+            }
+          }
+        }
+  }
+}

--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/SettingsViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/SettingsViewModel.kt
@@ -23,6 +23,7 @@ data class SettingsNav(
     val onNavigateToManagedBy: () -> Unit,
     val onNavigateToUserSwitcher: () -> Unit,
     val onNavigateToPermissions: () -> Unit,
+    val onNavigateToTrustedNetworks: () -> Unit,
     val onNavigateBackHome: () -> Unit,
     val onBackToSettings: () -> Unit,
 )

--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/TrustedNetworksViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/TrustedNetworksViewModel.kt
@@ -1,0 +1,84 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package com.tailscale.ipn.ui.viewModel
+
+import android.app.Application
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.net.wifi.WifiInfo
+import android.net.wifi.WifiManager
+import androidx.lifecycle.AndroidViewModel
+import com.tailscale.ipn.App
+import com.tailscale.ipn.autoconnect.TrustedNetworks
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class TrustedNetworksViewModel(application: Application) : AndroidViewModel(application) {
+
+  private val ctx = application.applicationContext
+
+  private val _enabled = MutableStateFlow(TrustedNetworks.isEnabled(ctx))
+  val enabled: StateFlow<Boolean> = _enabled.asStateFlow()
+
+  private val _trustedSsids = MutableStateFlow(TrustedNetworks.load(ctx))
+  val trustedSsids: StateFlow<Set<String>> = _trustedSsids.asStateFlow()
+
+  private val _currentSsid = MutableStateFlow<String?>(null)
+  val currentSsid: StateFlow<String?> = _currentSsid.asStateFlow()
+
+  init {
+    refreshCurrentSsid()
+  }
+
+  private fun reevaluate() {
+    App.get().networkWatcher.reevaluate()
+  }
+
+  fun setEnabled(enabled: Boolean) {
+    TrustedNetworks.setEnabled(ctx, enabled)
+    _enabled.value = enabled
+    reevaluate()
+  }
+
+  fun addSsid(ssid: String) {
+    TrustedNetworks.add(ctx, ssid)
+    _trustedSsids.value = TrustedNetworks.load(ctx)
+    reevaluate()
+  }
+
+  fun removeSsid(ssid: String) {
+    TrustedNetworks.remove(ctx, ssid)
+    _trustedSsids.value = TrustedNetworks.load(ctx)
+    reevaluate()
+  }
+
+  fun refreshCurrentSsid() {
+    val cm = ctx.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    val network = cm.activeNetwork ?: return
+    val caps = cm.getNetworkCapabilities(network) ?: return
+    if (caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
+      // Try transportInfo first (works on some Android versions)
+      var ssid =
+          (caps.transportInfo as? WifiInfo)
+              ?.ssid
+              ?.trim('"')
+              ?.takeIf { it.isNotBlank() && it != "<unknown ssid>" }
+
+      // Fallback to WifiManager
+      if (ssid == null) {
+        val wm = ctx.getSystemService(Context.WIFI_SERVICE) as WifiManager
+        @Suppress("DEPRECATION")
+        ssid =
+            wm.connectionInfo
+                ?.ssid
+                ?.trim('"')
+                ?.takeIf { it.isNotBlank() && it != "<unknown ssid>" }
+      }
+
+      _currentSsid.value = ssid
+    }
+  }
+}

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -242,6 +242,8 @@
     <string name="permission_write_external_storage_needed">We use storage in order to receive files with Taildrop.</string>
     <string name="permission_post_notifications">Notifications</string>
     <string name="permission_post_notifications_needed">We use notifications to help you troubleshoot broken connections, or notify you before you need to reauthenticate to your network. Persistent status notifications are off by default and can be enabled in system settings. </string>
+    <string name="permission_location">Location</string>
+    <string name="permission_location_needed">Required by Auto-VPN to detect the current Wi-Fi network name (SSID). Without this permission, VPN will stay enabled on all networks.</string>
     <string name="open_notification_settings">Go to notification settings</string>
     <string name="notification_settings_explanation">Persistent status notifications are off by default and can be enabled in system settings.</string>
     <string name="taildrop_dir">Taildrop directory</string>
@@ -309,6 +311,7 @@
     <string name="an_unknown_error_occurred_please_try_again">An unknown error occurred. Please try again.</string>
     <string name="request_timed_out_make_sure_that_is_online">Request timed out. Make sure that \'%1$s\' is online.</string>
     <string name="split_tunneling">App split tunneling</string>
+    <string name="auto_vpn">Auto-VPN</string>
     <string name="your_current_selection_will_be_cleared">Your current selection will be cleared.</string>
     <string name="filter_apps_allowed_to_access_tailscale">Filter what apps are allowed to access Tailscale.</string>
     <string name="selected_apps_will_access_the_internet_directly_without_using_tailscale">Apps you select will access the internet without using Tailscale.</string>


### PR DESCRIPTION
Summary

Add an Auto-VPN Manager that automatically enables/disables the Tailscale VPN tunnel based on the device's current network connection. When enabled, VPN is disabled on user-configured trusted Wi-Fi networks and enabled automatically on untrusted Wi-Fi, cellular data, or when no network is connected (fail-secure).
 
Motivation

Most commercial VPN clients already include network-based auto-connect as a core feature: 

- NordVPN --- "Auto-connect" with trusted Wi-Fi network list; VPN activates on untrusted networks
- ExpressVPN --- "Network Protection" that auto-connects on untrusted Wi-Fi and cellular
- Mullvad VPN --- "Auto-connect" on untrusted networks, with per-SSID trust configuration 
- Surfshark --- "Auto-connect" with trusted network whitelist
- WireGuard (Android) --- Supports "always-on VPN" at the OS level, but lacks network-aware toggling
- OpenVPN Connect --- Supports trusted network detection via "Seamless Tunnel"

Tailscale's Android client currently lacks this capability --- users must manually toggle VPN on/off when moving between home and public networks. This creates two problems:

1. Security risk: Users forget to enable VPN on untrusted networks (coffee shops, hotels, airports), exposing traffic 
2. Unnecessary overhead: VPN stays active on trusted home networks where it isn't needed, adding latency and battery drain for local network traffic

The Auto-VPN feature addresses both by applying a simple, proven model: maintain a user-defined list of trusted SSIDs, and automatically toggle VPN based on whether the current network is trusted. This is the same approach used by the VPN clients listed above, and is the most commonly requested missing feature in Tailscale's mobile clients.

The implementation is fail-secure by design --- if the SSID cannot be determined (location permission denied, transient state, unknown network), VPN defaults to enabled, ensuring the user is never left unprotected.

New files 

- autoconnect/TrustedNetworks.kt --- SharedPreferences persistence for trusted SSID list and feature toggle 
- autoconnect/NetworkWatcher.kt --- ConnectivityManager.NetworkCallback with debounced evaluation, VPN network filtering, action deduplication, and triple SSID detection fallback
- ui/view/TrustedNetworksView.kt --- Jetpack Compose settings screen with feature toggle, current network detection, manual SSID entry, trusted network list, and runtime location permission 
handling
- ui/viewModel/TrustedNetworksViewModel.kt --- ViewModel with re-evaluation on settings changes 

Modified files

- App.kt --- Register/unregister NetworkWatcher in lifecycle
- MainActivity.kt --- Add "trustedNetworks" route and SettingsNav callback
- SettingsView.kt --- Add Auto-VPN menu entry in settings 
- SettingsViewModel.kt --- Extend SettingsNav with onNavigateToTrustedNetworks
- Permissions.kt --- Add ACCESS_FINE_LOCATION to permissions list 
- AndroidManifest.xml --- Add ACCESS_FINE_LOCATION permission 
- strings.xml --- Add auto_vpn, permission_location string resources

Technical notes 
 
- SSID detection uses triple fallback: NetworkCapabilities.transportInfo >> WifiManager.connectionInfo >> WifiManager.scanResults (matched by BSSID) for Android 12-16 compatibility
- Network callbacks are debounced (2s) to prevent rapid toggling from signal strength changes
- VPN network events (TRANSPORT_VPN) are filtered in callbacks and evaluateCurrent() iterates cm.allNetworks instead of using cm.activeNetwork, since VPN becomes the active network when 
running 
- Settings changes (add/remove SSID, toggle feature) trigger immediate re-evaluation

Test plan 

- Auto-VPN settings screen accessible from Settings 
- Feature enable/disable toggle works
- Location permission prompted on enable
- Current SSID detected and displayed (Android 16)
- "Trust current network" button adds SSID, VPN disables
- Removing trusted network enables VPN
- Manual SSID entry works 
- VPN enables on cellular / no network
- No feedback loop when VPN starts (VPN network filtered)
- No rapid toggling (debounced callbacks) 
- Location permission shows in Settings >> Permissions 
- Tested on Samsung and Pixel phones, Android 16 (API 36); tested also on Samsung Galaxy Tab 5