### PR TITLE
Makefile: add docker-tailscale-debug target with persistent debug keystore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,10 @@ tailscale.jks
 # android sdk dir
 ./android-sdk
 
+# Persistent $HOME/.android for `make docker-*` (keeps debug.keystore so
+# the debug signer is stable across container runs).
+.android-docker
+
 # Java profiling output
 *.hprof
 

--- a/Makefile
+++ b/Makefile
@@ -365,9 +365,28 @@ docker-build-image: ## Builds the docker image for the android build environment
 		docker build -f docker/DockerFile.amd64-build -t $(DOCKER_IMAGE) .; \
 	fi
 
+# DOCKER_ANDROID_DIR is bind-mounted as /root/.android inside the container
+# so the Gradle-generated debug keystore (and anything else under ~/.android)
+# persists across docker runs. Without this, every docker-based debug build
+# gets a fresh debug.keystore and a different signing cert, so `adb install -r`
+# can't update a prior install. Mount target is /root/.android because the
+# JVM's user.home resolves to /root for the container's root user, regardless
+# of the Dockerfile's HOME=/build env.
+DOCKER_ANDROID_DIR := $(CURDIR)/.android-docker
+
+.PHONY: docker-android-dir
+docker-android-dir:
+	@mkdir -p $(DOCKER_ANDROID_DIR)
+
+DOCKER_RUN_VOLS := -v $(CURDIR):/build/tailscale-android -v $(DOCKER_ANDROID_DIR):/root/.android
+
 .PHONY: docker-run-build
-docker-run-build: clean jarsign-env docker-build-image ## Runs the docker image for the android build environment and builds release
-	@docker run --rm -v $(CURDIR):/build/tailscale-android --env JKS_PASSWORD=$(JKS_PASSWORD) --env JKS_PATH=$(JKS_PATH) $(DOCKER_IMAGE)
+docker-run-build: clean jarsign-env docker-build-image docker-android-dir ## Runs the docker image for the android build environment and builds release
+	@docker run --rm $(DOCKER_RUN_VOLS) --env JKS_PASSWORD=$(JKS_PASSWORD) --env JKS_PATH=$(JKS_PATH) $(DOCKER_IMAGE)
+
+.PHONY: docker-tailscale-debug
+docker-tailscale-debug: docker-build-image docker-android-dir ## Build tailscale-debug.apk inside the docker env (stable signer across runs)
+	@docker run --rm $(DOCKER_RUN_VOLS) $(DOCKER_IMAGE) make tailscale-debug
 
 .PHONY: docker-remove-build-image
 docker-remove-build-image: ## Removes the current docker build image
@@ -377,8 +396,8 @@ docker-remove-build-image: ## Removes the current docker build image
 docker-all: docker-build-image docker-run-build $(DOCKER_IMAGE)
 
 .PHONY: docker-shell
-docker-shell: docker-build-image ## Builds a docker image with the android build env and opens a shell
-	docker run --rm -v $(CURDIR):/build/tailscale-android -it $(DOCKER_IMAGE) /bin/bash
+docker-shell: docker-build-image docker-android-dir ## Builds a docker image with the android build env and opens a shell
+	docker run --rm $(DOCKER_RUN_VOLS) -it $(DOCKER_IMAGE) /bin/bash
 
 .PHONY: docker-remove-shell-image
 docker-remove-shell-image: ## Removes all docker shell image


### PR DESCRIPTION
The existing docker-run-build target is geared at release builds and
requires JKS signing env vars. There was no ergonomic path for the
common "iterate on a debug APK inside the build container" workflow.
Worse, every docker run produces an APK signed with a fresh ephemeral
debug keystore, so `adb install -r` refuses to update a prior install.

Add a docker-tailscale-debug target that builds the debug APK inside
the container, and bind-mount $(CURDIR)/.android-docker (gitignored)
at /root/.android in every docker-* target so the Gradle-generated
debug.keystore survives across invocations. Signer stays stable across
builds in the same checkout.

Note: mount target is /root/.android rather than the Dockerfile's
HOME=/build because the JVM's user.home resolves from /etc/passwd
(i.e. /root for uid 0), not from the HOME env var.

Made while working on tailscale/tailscale-android#695

Updates #13174
Updates tailscale/tailscale-android#695
