### PR TITLE
android: add search bar to split-tunnel app picker

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/ui/view/SplitTunnelAppPickerView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/SplitTunnelAppPickerView.kt
@@ -8,13 +8,16 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
@@ -23,6 +26,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -49,6 +53,8 @@ fun SplitTunnelAppPickerView(
     model: SplitTunnelAppPickerViewModel = viewModel(),
 ) {
   val installedApps by model.installedApps.collectAsState()
+  val filteredApps by model.filteredApps.collectAsState()
+  val searchQuery by model.searchQuery.collectAsState()
   val selectedPackageNames by model.selectedPackageNames.collectAsState()
   val allowSelected by model.allowSelected.collectAsState()
   val builtInDisallowedPackageNames: List<String> = App.get().builtInDisallowedPackageNames
@@ -118,6 +124,28 @@ fun SplitTunnelAppPickerView(
                   selectedPackageNames.count(),
               ))
         }
+        item("searchBar") {
+          OutlinedTextField(
+              value = searchQuery,
+              onValueChange = { model.updateSearchQuery(it) },
+              placeholder = { Text(stringResource(R.string.search_ellipsis)) },
+              leadingIcon = {
+                Icon(Icons.Default.Search, contentDescription = null)
+              },
+              trailingIcon = {
+                if (searchQuery.isNotEmpty()) {
+                  IconButton(onClick = { model.updateSearchQuery("") }) {
+                    Icon(
+                        Icons.Default.Close,
+                        contentDescription = stringResource(R.string.clear_search))
+                  }
+                }
+              },
+              singleLine = true,
+              modifier =
+                  Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp),
+          )
+        }
         if (installedApps.isEmpty()) {
           item("spinner") {
             Box(
@@ -132,7 +160,7 @@ fun SplitTunnelAppPickerView(
             }
           }
         } else {
-          items(installedApps, key = { it.packageName }) { app ->
+          items(filteredApps, key = { it.packageName }) { app ->
             ListItem(
                 headlineContent = { Text(app.name, fontWeight = FontWeight.SemiBold) },
                 leadingContent = {

--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/SplitTunnelAppPickerViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/SplitTunnelAppPickerViewModel.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.stateIn
@@ -37,6 +38,28 @@ class SplitTunnelAppPickerViewModel : ViewModel() {
               initialValue = listOf(),
           )
   val selectedPackageNames: StateFlow<List<String>> = MutableStateFlow(listOf())
+
+  private val _searchQuery = MutableStateFlow("")
+  val searchQuery: StateFlow<String> = _searchQuery
+
+  val filteredApps: StateFlow<List<InstalledApp>> =
+      combine(installedApps, _searchQuery) { apps, query ->
+            if (query.isBlank()) apps
+            else
+                apps.filter { app ->
+                  app.name.contains(query, ignoreCase = true) ||
+                      app.packageName.contains(query, ignoreCase = true)
+                }
+          }
+          .stateIn(
+              scope = viewModelScope,
+              started = SharingStarted.WhileSubscribed(5000),
+              initialValue = listOf(),
+          )
+
+  fun updateSearchQuery(query: String) {
+    _searchQuery.value = query
+  }
 
   val allowSelected: StateFlow<Boolean> = MutableStateFlow(App.get().allowSelectedPackages())
   val showHeaderMenu: StateFlow<Boolean> = MutableStateFlow(false)


### PR DESCRIPTION
## Problem

The split-tunnel app selection screen lists all installed apps in a single
scrollable list. On devices with many apps (100+), finding a specific app
requires tedious scrolling. There is no way to filter by name or package name.

## Solution

Add a search/filter bar at the top of the app list in the split-tunnel app
picker. The search matches against both app display names and package names
(case-insensitive). Typing a query filters the list in real-time; a clear
button (✕) appears when the field is non-empty.

### Changes

**SplitTunnelAppPickerViewModel.kt** (+22 lines)
- New `_searchQuery` / `searchQuery` state for tracking search input
- New `filteredApps` StateFlow that combines `installedApps` with
  `_searchQuery` via `combine()` — re-filters on every keystroke
- New `updateSearchQuery()` method exposed to the View

**SplitTunnelAppPickerView.kt** (+30 lines, -1 line)
- Added an `OutlinedTextField` search bar in the LazyColumn, positioned
  between the section divider header and the app list
- Leading icon: search (🔍)
- Trailing icon: clear (✕), visible only when the field is non-empty
- Changed `items(installedApps, ...)` to `items(filteredApps, ...)`

No new string resources — reuses existing `search_ellipsis` and
`clear_search` strings. No new permissions, no backend changes.

### Implementation details

```kotlin
val filteredApps: StateFlow<List<InstalledApp>> =
    combine(installedApps, _searchQuery) { apps, query ->
        if (query.isBlank()) apps
        else apps.filter { app ->
            app.name.contains(query, ignoreCase = true) ||
            app.packageName.contains(query, ignoreCase = true)
        }
    }.stateIn(...)
```

### Testing notes

- Search works on both app name (Chrome) and package name (com.android.chrome)
- Japanese/Chinese/emoji app names — String.contains handles Unicode naturally
- Empty search shows all apps; clearing restores the full list
- Loading spinner still triggers on the full `installedApps` list, not the
  filtered subset, so the spinner appears correctly during app enumeration
- Selection state is unaffected by filtering
- MDM mode: unchanged (search bar is not shown when MDM overrides are active)

### Related

- Updates tailscale/tailscale#13816 (Feature Request: allowlist mode for Android)
- Continues from the split-tunnel UX landed in PR #621
- Simpler scope than PR #724 (which also attempted a search bar but had a
  much larger +482/-95 diff including include-mode routing changes)