### PR TITLE
android: fix severity sorting

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/ui/model/Health.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/model/Health.kt
@@ -36,7 +36,7 @@ class Health {
 
     override fun compareTo(other: UnhealthyState): Int {
       // Compare by severity first
-      val severityComparison = other.Severity.compareTo(other.Severity)
+      val severityComparison = other.Severity.compareTo(Severity)
       if (severityComparison != 0) {
         return severityComparison
       }


### PR DESCRIPTION
The previous fix attempt resulted in comparing other.Severity to itself, which always returns 0. This compares the other item's severity to this item's severity.

Updates tailscale/corp#41733