### PR TITLE
android: push default gateway IP from LinkProperties to go backend

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/NetworkChangeCallback.kt
+++ b/android/src/main/java/com/tailscale/ipn/NetworkChangeCallback.kt
@@ -197,6 +197,14 @@ object NetworkChangeCallback {
 
     if (dns.updateDNSFromNetwork(sb.toString())) {
       TSLog.d(TAG, "$why: updated DNS config for iface=${info.linkProps.interfaceName}")
+
+      val gatewayIP =
+          info.linkProps.routes
+              .filter { it.isDefaultRoute && it.gateway != null }
+              .sortedBy { if (it.gateway is java.net.Inet4Address) 0 else 1 }
+              .firstNotNullOfOrNull { it.gateway?.hostAddress } ?: ""
+
+      Libtailscale.onGatewayChanged(gatewayIP)
       Libtailscale.onDNSConfigChanged(info.linkProps.interfaceName)
     }
   }

--- a/libtailscale/callbacks.go
+++ b/libtailscale/callbacks.go
@@ -5,6 +5,8 @@ package libtailscale
 
 import (
 	"sync"
+
+	"tailscale.com/net/netmon"
 )
 
 var (
@@ -34,6 +36,11 @@ func OnDNSConfigChanged(ifname string) {
 	case onDNSConfigChanged <- ifname:
 	default:
 	}
+}
+
+// OnGatewayChanged is called when LinkProperties provides an updated default gateway IP.
+func OnGatewayChanged(gatewayIP string) {
+	netmon.UpdateLastKnownDefaultGateway(gatewayIP)
 }
 
 var android struct {


### PR DESCRIPTION
likelyHomeRouterIPHelper was replaced with a cached gateway read in 86f9e7a9ea47e368e394a8e4e1866bbd40e6ed4a. This provides the value by retrieving the default gateway from LinkProperties.getRoute() in NetworkChangeCallback on every onLinkPropertiesChanged event.

Updates tailscale/tailscale#18622
Updates tailscale/tailscale#13352