### PR TITLE
android: derive versionCode from tailscale version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ $(RELEASE_AAB): version gradle-dependencies
 
 $(RELEASE_TV_AAB): version gradle-dependencies
 	@echo "Building TV release AAB"
-	(cd android && ./gradlew test bundleRelease_tv)
+	(cd android && ./gradlew test bundleTvRelease -PPLATFORM=1) 
 	install -C ./android/build/outputs/bundle/release_tv/android-release_tv.aab $@
 
 tailscale-test.apk: version gradle-dependencies
@@ -278,10 +278,6 @@ tag_release: debug-symbols tailscale.version ## Tag the current commit with the 
 bumposs: update-oss tailscale.version
 	source tailscale.version && git commit -sm "android: bump OSS" -m "OSS and Version updated to $${VERSION_LONG}" go.toolchain.rev android/build.gradle go.mod go.sum
 	source tailscale.version && git tag -a "$${VERSION_LONG}" -m "OSS and Version updated to $${VERSION_LONG}"
-
-.PHONY: bump_version_code ## Bump the version code in build.gradle
-bump_version_code:
-	sed -i'.bak' "s/versionCode .*/versionCode $$(expr $$(awk '/versionCode ([0-9]+)/{print $$2}' android/build.gradle) + 1)/" android/build.gradle && rm android/build.gradle.bak
 
 .PHONY: update-oss ## Update the tailscale.com go module
 update-oss:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,7 @@ android {
     defaultConfig {
         minSdkVersion 26
         targetSdkVersion 35
-        versionCode 615
+        versionCode computeVersionCode()
         versionName getVersionProperty("VERSION_LONG")
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
@@ -195,3 +195,15 @@ def getVersionProperty(key) {
     versionProps.load(project.file('../tailscale.version').newDataInputStream())
     return versionProps.getProperty(key).replaceAll('^\"|\"$', '')
 }
+
+def computeVersionCode() {
+    def versionProps = new Properties()
+    versionProps.load(project.file('../tailscale.version').newDataInputStream())
+    
+    def major = versionProps.getProperty('VERSION_MAJOR') as int
+    def minor = versionProps.getProperty('VERSION_MINOR') as int
+    def patch = versionProps.getProperty('VERSION_PATCH') as int
+    def platform = (project.findProperty('PLATFORM') ?: '0') as int
+    
+    return major * 100000000 + minor * 100000 + patch * 10 + platform
+}          

--- a/docker/DockerFile.amd64-build
+++ b/docker/DockerFile.amd64-build
@@ -43,4 +43,4 @@ RUN chmod 755 android/gradlew && \
     ./android/gradlew
 
 # Build the android app, bump the playstore version code, and make the tv release
-CMD make clean && make release && make bump_version_code && make release-tv
+CMD make clean && make release && make release-tv


### PR DESCRIPTION
Previously, versionCode was only set by the Play Store builder and never committed back to the repo, so fdroid wouldn't detect updates.
Now, we compute versionCode deterministically using the formula major*100M + minor*100K + patch*10 + platform, so that fdroid and Play Store builds always produce the same value.

Updates https://github.com/tailscale/tailscale/issues/18969

Signed-off-by: kari-ts <kari@tailscale.com>