### PR TITLE
android: add launcher shortcuts to connect and disconnect the VPN

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -57,6 +57,30 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE_PREFERENCES" />
             </intent-filter>
+            <!-- Static app shortcuts must be attached to the LAUNCHER activity. -->
+            <meta-data
+                android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
+        </activity>
+
+        <!--
+            Transparent, no-UI trampoline that connects or disconnects the VPN. Exported so the
+            actions show up in the launcher long-press shortcut menu, Samsung Modes & Routines, and
+            can be sent from Tasker. Starting an activity (rather than IPNReceiver's broadcast)
+            reliably wakes a stopped app so connect can start the foreground VPN service.
+        -->
+        <activity
+            android:name="AutomationActivity"
+            android:exported="true"
+            android:excludeFromRecents="true"
+            android:noHistory="true"
+            android:taskAffinity=""
+            android:theme="@android:style/Theme.NoDisplay">
+            <intent-filter>
+                <action android:name="com.tailscale.ipn.CONNECT_VPN" />
+                <action android:name="com.tailscale.ipn.DISCONNECT_VPN" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
         </activity>
         <activity
             android:name="ShareActivity"

--- a/android/src/main/java/com/tailscale/ipn/AutomationActivity.kt
+++ b/android/src/main/java/com/tailscale/ipn/AutomationActivity.kt
@@ -1,0 +1,63 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+package com.tailscale.ipn
+
+import android.app.Activity
+import android.content.Intent
+import android.net.VpnService
+import android.os.Bundle
+import com.tailscale.ipn.util.TSLog
+
+/**
+ * AutomationActivity is a transparent, no-UI trampoline that connects or disconnects the VPN and
+ * finishes immediately. It backs the launcher long-press shortcuts and can also be invoked from
+ * Samsung Modes and Routines or Tasker.
+ *
+ * It is an activity rather than an extension of [IPNReceiver]'s broadcasts because starting an
+ * activity reliably wakes an app that the OS has force-stopped or put into deep sleep, e.g. under
+ * Samsung battery management. The brief foreground also lets connect start the VPN service without
+ * hitting the Android 12+ restriction on starting a foreground service from the background, which
+ * the broadcast path can trip when the app has been idle.
+ */
+class AutomationActivity : Activity() {
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+
+    when (intent?.action) {
+      IPNReceiver.INTENT_CONNECT_VPN -> connect()
+      IPNReceiver.INTENT_DISCONNECT_VPN -> UninitializedApp.get().stopVPN()
+      else -> TSLog.w(TAG, "unknown action: ${intent?.action}")
+    }
+
+    // Never show any UI: finish before this activity becomes visible.
+    finish()
+  }
+
+  /**
+   * Starts the VPN directly when it is ready and consent is already granted. Otherwise (not set up,
+   * or consent not yet granted) opens the app, which handles login and the consent prompt.
+   */
+  private fun connect() {
+    val app = UninitializedApp.get()
+    if (app.isAbleToStartVPN() && VpnService.prepare(this) == null) {
+      app.startVPN()
+    } else {
+      launchMainActivity()
+    }
+  }
+
+  private fun launchMainActivity() {
+    val intent =
+        Intent(this, MainActivity::class.java).apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) }
+    try {
+      startActivity(intent)
+    } catch (e: Exception) {
+      TSLog.e(TAG, "Failed to launch MainActivity: $e")
+    }
+  }
+
+  companion object {
+    private const val TAG = "AutomationActivity"
+  }
+}

--- a/android/src/main/java/com/tailscale/ipn/ui/localapi/Client.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/localapi/Client.kt
@@ -306,11 +306,24 @@ class Request<T>(
     fun setApp(newApp: libtailscale.Application) {
       app = newApp
     }
+
+    // Returns the libtailscale app, initializing the backend on demand. A localAPI request can be
+    // issued from a cold-started process (e.g. UseExitNodeWorker, kicked off by IPNReceiver) that
+    // never went through App.get(), so setApp() may not have run yet. Resolving lazily here mirrors
+    // Client's own lazy `app` and avoids crashing the process with an
+    // UninitializedPropertyAccessException.
+    private fun resolveApp(): libtailscale.Application {
+      if (!::app.isInitialized) {
+        app = App.get().getLibtailscaleApp()
+      }
+      return app
+    }
   }
 
   @OptIn(ExperimentalSerializationApi::class)
   fun execute() {
     scope.launch(Dispatchers.IO) {
+      val app = resolveApp()
       TSLog.d(TAG, "Executing request:${method}:${fullPath} on app $app")
       try {
         val resp =

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -378,4 +378,10 @@
     <string name="enable_hardware_attestation">Enable hardware attestation</string>
     <string name="use_hardware_backed_keys_to_bind_node_identity_to_the_device">Use hardware-backed keys to bind node identity to the device</string>
 
+    <!-- App shortcuts (launcher long-press, Tasker, Samsung Modes &amp; Routines) -->
+    <string name="shortcut_connect_short">Connect</string>
+    <string name="shortcut_connect_long">Connect to Tailscale</string>
+    <string name="shortcut_disconnect_short">Disconnect</string>
+    <string name="shortcut_disconnect_long">Disconnect from Tailscale</string>
+
 </resources>

--- a/android/src/main/res/xml/shortcuts.xml
+++ b/android/src/main/res/xml/shortcuts.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Tailscale Inc & AUTHORS -->
+<!-- SPDX-License-Identifier: BSD-3-Clause -->
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <shortcut
+        android:shortcutId="connect"
+        android:enabled="true"
+        android:icon="@drawable/ic_launcher_foreground"
+        android:shortcutShortLabel="@string/shortcut_connect_short"
+        android:shortcutLongLabel="@string/shortcut_connect_long">
+        <intent
+            android:action="com.tailscale.ipn.CONNECT_VPN"
+            android:targetPackage="com.tailscale.ipn"
+            android:targetClass="com.tailscale.ipn.AutomationActivity" />
+    </shortcut>
+
+    <shortcut
+        android:shortcutId="disconnect"
+        android:enabled="true"
+        android:icon="@drawable/ic_launcher_foreground"
+        android:shortcutShortLabel="@string/shortcut_disconnect_short"
+        android:shortcutLongLabel="@string/shortcut_disconnect_long">
+        <intent
+            android:action="com.tailscale.ipn.DISCONNECT_VPN"
+            android:targetPackage="com.tailscale.ipn"
+            android:targetClass="com.tailscale.ipn.AutomationActivity" />
+    </shortcut>
+</shortcuts>


### PR DESCRIPTION
## Summary

Adds two static launcher shortcuts — **Connect** and **Disconnect** — backed by a transparent, no-UI `AutomationActivity` trampoline on the existing `CONNECT_VPN` / `DISCONNECT_VPN` intents. The actions can also be invoked from Samsung Modes & Routines and Tasker (Send Intent → Activity).

## Why an activity rather than the existing broadcast

I wrote the original `IPNReceiver` broadcast support, and it worked reliably when it landed. Over successive Android releases the background-execution and power-saving restrictions have tightened (Doze, app standby, and OEM battery managers like Samsung's deep sleep), and the broadcast path has become unreliable at waking an app that's been stopped or slept — it often can't start the foreground VPN service from that state.

Starting an *activity* avoids this: it wakes the app and lets connect start the foreground VPN service. The existing broadcast actions are unchanged.

## On-device validation

On a Galaxy S25 (SM-S948B, Android 16), with Tailscale put into deep sleep (hibernated + background-execution denied + restricted standby bucket + force-stopped) and triggered by **real Tasker intents**:
- Broadcast → `IPNReceiver`: **failed to connect**
- Activity → `AutomationActivity`: **connected** — both screen-on and screen-off

## Notes for reviewers

- **Exported without a permission** is deliberate: the same CONNECT/DISCONNECT actions are already reachable unguarded via the existing exported `IPNReceiver`. This adds an activity entry point for the reliable foreground-wake path, not new capability.
- **First run / not set up:** if the user isn't logged in or VPN consent hasn't been granted, the shortcut opens the app (which owns login and the consent prompt) rather than one-tap connecting.
- **Exit-node automation is unchanged** and remains available via the existing `IPNReceiver` `USE_EXIT_NODE` broadcast once connected.

## Related issues

Implements the launcher-shortcut / automation requests in tailscale/tailscale#9531, tailscale/tailscale#9497, tailscale/tailscale#16415, tailscale/tailscale#17855, and tailscale/tailscale#17738, and improves the broadcast-intent reliability reported in tailscale/tailscale#10831, tailscale/tailscale#14148, tailscale/tailscale#13623, and tailscale/tailscale#18847.


## Also fixes a cold-start crash

Found while testing the shortcuts against a force-stopped app. A localAPI call from a cold process (e.g. `UseExitNodeWorker`, started by `IPNReceiver`) reads `Request`'s `lateinit app` before the backend is initialized, so it crashes with `UninitializedPropertyAccessException`. `execute()` now resolves the app lazily via `App.get()`, the same way `Client` already does.
