### PR TITLE
makefile: adjust tv build for versioning changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,8 +151,8 @@ $(RELEASE_AAB): version gradle-dependencies
 
 $(RELEASE_TV_AAB): version gradle-dependencies
 	@echo "Building TV release AAB"
-	(cd android && ./gradlew test bundleTvRelease -PPLATFORM=1) 
-	install -C ./android/build/outputs/bundle/release_tv/android-release_tv.aab $@
+	(cd android && ./gradlew test bundleRelease -PPLATFORM=1) 
+	install -C ./android/build/outputs/bundle/release/android-release.aab $@
 
 tailscale-test.apk: version gradle-dependencies
 	(cd android && ./gradlew assembleApplicationTestAndroidTest)


### PR DESCRIPTION
Updates tailscale/tailscale#18969

gradle now treats tv and phone builds as the same thing - simply
changing the last digit of the android version.   Adjusting the
makefile accordingly so we're building the right thing, and looking
in the right places for the build output.