### PR TITLE
build.gradle: bump to API level 35 for compliance

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,10 +33,10 @@ apply plugin: 'com.ncorti.ktfmt.gradle'
 
 android {
     ndkVersion "23.1.7779620"
-    compileSdkVersion 34
+    compileSdkVersion 36
     defaultConfig {
         minSdkVersion 26
-        targetSdkVersion 35
+        targetSdkVersion 36
         // versionCode is written here by `make bumposs` / `make tag_release`
         // (base = major*100000000 + minor*100000 + patch*10). AndroidTV builds
         // increment this by 1 in the Makefile's release-tv target so the two

--- a/android/src/main/java/com/tailscale/ipn/util/TSLog.kt
+++ b/android/src/main/java/com/tailscale/ipn/util/TSLog.kt
@@ -53,7 +53,7 @@ object TSLog {
         appContext.packageManager.getPackageInfo(appContext.packageName, 0).versionName
 
     // Extract the middle number and check if it's odd
-    val middleNumber = versionName.split(".").getOrNull(1)?.toIntOrNull()
+    val middleNumber = versionName?.split(".")?.getOrNull(1)?.toIntOrNull()
     return middleNumber?.let { it % 2 == 1 } ?: false
   }
 


### PR DESCRIPTION
Android 16 (API level 36) or higher is required by August 30. Two optionals added to fix compilation.

updates tailscale/corp#40476