### PR TITLE
Makefile: bump API level to 36

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # with this name, it will be used.
 #
 # The convention here is tailscale-android-build-amd64-<date>
-DOCKER_IMAGE := tailscale-android-build-amd64-070325-1
+DOCKER_IMAGE := tailscale-android-build-amd64-072226-2
 
 # The integration test image contains the Android emulator, system image, SDK,
 # build-tools, NDK, adb, and helper tools needed to run the emulator-backed Go
@@ -26,6 +26,15 @@ export TS_USE_TOOLCHAIN=1
 # As of 2026-04-15, we disable netmap caching on Android until we have UI
 # affordances for debugging it.
 GOMOBILE_BUILD_TAGS := ts_omit_cachenetmap
+
+# Pull androidApiLevel from gradle.properties.
+ANDROID_API_LEVEL := $(shell grep '^androidApiLevel=' android/gradle.properties | cut -d'=' -f2)
+
+ifeq ($(ANDROID_API_LEVEL),)
+$(error androidApiLevel missing from android/gradle.properties)
+endif
+
+ANDROID_BUILD_TOOLS_VERSION := $(shell grep '^androidBuildToolsVersion=' android/gradle.properties | cut -d'=' -f2)
 
 DEBUG_APK := tailscale-debug.apk
 RELEASE_AAB := tailscale-release.aab
@@ -47,7 +56,7 @@ else
     ANDROID_TOOLS_URL := "https://dl.google.com/android/repository/commandlinetools-mac-9477386_latest.zip"
     ANDROID_TOOLS_SUM := "2072ffce4f54cdc0e6d2074d2f381e7e579b7d63e915c220b96a7db95b2900ee  commandlinetools-mac-9477386_latest.zip"
 endif
-ANDROID_SDK_PACKAGES := 'platforms;android-34' 'extras;android;m2repository' 'ndk;23.1.7779620' 'platform-tools' 'build-tools;34.0.0'
+ANDROID_SDK_PACKAGES := 'platforms;android-$(ANDROID_API_LEVEL)' 'extras;android;m2repository' 'ndk;23.1.7779620' 'platform-tools' 'build-tools;$(ANDROID_BUILD_TOOLS_VERSION)'
 
 # Attempt to find an ANDROID_SDK_ROOT / ANDROID_HOME based either from
 # preexisting environment or common locations.
@@ -91,7 +100,7 @@ else
     export PATH := $(JAVA_HOME)/bin:$(PATH)
 endif
 
-AVD_BASE_IMAGE := "system-images;android-33;google_apis;"
+AVD_BASE_IMAGE := 'system-images;android-$(ANDROID_API_LEVEL);google_apis;'
 export HOST_ARCH := $(shell uname -m)
 ifeq ($(HOST_ARCH),aarch64)
     AVD_IMAGE := "$(AVD_BASE_IMAGE)arm64-v8a"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,11 +32,13 @@ apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 apply plugin: 'com.ncorti.ktfmt.gradle'
 
 android {
+    def androidApiLevel = providers.gradleProperty("androidApiLevel").get().toInteger()
+
     ndkVersion "23.1.7779620"
-    compileSdkVersion 36
+    compileSdkVersion androidApiLevel
     defaultConfig {
         minSdkVersion 26
-        targetSdkVersion 36
+        targetSdkVersion androidApiLevel
         // versionCode is written here by `make bumposs` / `make tag_release`
         // (base = major*100000000 + minor*100000 + patch*10). AndroidTV builds
         // increment this by 1 in the Makefile's release-tv target so the two

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,5 @@
+androidApiLevel=36
+androidBuildToolsVersion=36.0.0
 android.defaults.buildfeatures.buildconfig=true
 android.nonFinalResIds=false
 android.nonTransitiveRClass=true

--- a/docker/DockerFile.amd64-build
+++ b/docker/DockerFile.amd64-build
@@ -1,7 +1,7 @@
 # This is a Dockerfile for creating a build environment for
 # tailscale-android.
 
-FROM --platform=linux/amd64 eclipse-temurin:21
+FROM --platform=linux/amd64 eclipse-temurin:21-jdk-jammy
 
 ENV HOME /build
 ENV ANDROID_HOME $HOME/android-sdk
@@ -24,13 +24,14 @@ RUN chmod 755 /tmp/docker-build-apt-get.sh && \
 # to run "go run tailscale.com/cmd/printdep" to figure out which Tailscale Go
 # version we need later, but otherwise this toolchain isn't used:
 RUN \
-    curl -L https://go.dev/dl/go1.24.1.linux-amd64.tar.gz | tar -C /usr/local -zxv && \
+    curl -L https://go.dev/dl/go1.26.5.linux-amd64.tar.gz | tar -C /usr/local -zxv && \
     ln -s /usr/local/go/bin/go /usr/bin
 
 RUN git config --global --add safe.directory $HOME/tailscale-android
 WORKDIR $HOME/tailscale-android
 
 COPY Makefile Makefile
+COPY android/gradle.properties android/gradle.properties
 
 # Get android sdk, ndk, and rest of the stuff needed to build the android app.
 RUN make androidsdk


### PR DESCRIPTION
Sets gradle.properties for API level that is shared across various tooling steps.

updates tailscale/corp#40476