### PR TITLE
android: allow HealthView banner content to be copied

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ libtailscale-sources.jar
 .DS_Store
 
 tailscale.version
+
+# local tmp folder
+.tmp/

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ release-tv: jarsign-env $(RELEASE_TV_AAB)
 
 # gradle-dependencies groups together the android sources and libtailscale needed to assemble tests/debug/release builds.
 .PHONY: gradle-dependencies
-gradle-dependencies: $(shell find android -type f -not -path "android/build/*" -not -path '*/.*') $(LIBTAILSCALE_AAR) tailscale.version
+gradle-dependencies: $(shell find android -type f -not -path "android/build/*" -not -path "android/libs/*" -not -path '*/.*') $(LIBTAILSCALE_AAR) tailscale.version
 
 $(RELEASE_AAB): version gradle-dependencies
 	@echo "Building release AAB"

--- a/android/src/main/java/com/tailscale/ipn/ui/model/Health.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/model/Health.kt
@@ -34,6 +34,10 @@ class Health {
       } == true
     }
 
+    /** Hydrated value copied to the clipboard for debugging. */
+    val clipboardText: String
+      get() = "$WarnableCode: $Title" + if (Text.isNotEmpty()) "\n$Text" else ""
+
     override fun compareTo(other: UnhealthyState): Int {
       // Compare by severity first
       val severityComparison = other.Severity.compareTo(Severity)

--- a/android/src/main/java/com/tailscale/ipn/ui/view/HealthView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/HealthView.kt
@@ -3,7 +3,11 @@
 
 package com.tailscale.ipn.ui.view
 
+import android.os.Build
+import android.widget.Toast
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -13,6 +17,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
@@ -21,16 +27,23 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.tailscale.ipn.R
 import com.tailscale.ipn.ui.model.Health
 import com.tailscale.ipn.ui.theme.success
+import com.tailscale.ipn.ui.util.AndroidTVUtil.isAndroidTV
 import com.tailscale.ipn.ui.viewModel.HealthViewModel
 
 @Composable
@@ -73,8 +86,22 @@ fun HealthView(backToSettings: BackNavigation, model: HealthViewModel = viewMode
   }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun HealthWarningView(warning: Health.UnhealthyState) {
+  val localClipboardManager = LocalClipboardManager.current
+  val context = LocalContext.current
+  val copiedText = stringResource(R.string.copied)
+  var menuExpanded by remember { mutableStateOf(false) }
+
+  // Android TV has no clipboard.
+  val itemModifier =
+      if (isAndroidTV()) {
+        Modifier
+      } else {
+        Modifier.combinedClickable(onClick = {}, onLongClick = { menuExpanded = true })
+      }
+
   Box(modifier = Modifier.background(color = MaterialTheme.colorScheme.surfaceContainerLow)) {
     Box(
         modifier =
@@ -82,6 +109,7 @@ fun HealthWarningView(warning: Health.UnhealthyState) {
                 .clip(shape = RoundedCornerShape(10.dp, 10.dp, 10.dp, 10.dp))
                 .fillMaxWidth()) {
           ListItem(
+              modifier = itemModifier,
               colors = warning.Severity.listItemColors(),
               headlineContent = {
                 if (warning.Title.isNotEmpty()) {
@@ -94,6 +122,23 @@ fun HealthWarningView(warning: Health.UnhealthyState) {
               supportingContent = {
                 Text(warning.Text, style = MaterialTheme.typography.bodyMedium)
               })
+
+          // Copy for now; KB-page links to follow.
+          DropdownMenu(expanded = menuExpanded, onDismissRequest = { menuExpanded = false }) {
+            DropdownMenuItem(
+                leadingIcon = {
+                  Icon(painter = painterResource(R.drawable.clipboard), contentDescription = null)
+                },
+                text = { Text(text = stringResource(R.string.copy)) },
+                onClick = {
+                  localClipboardManager.setText(AnnotatedString(warning.clipboardText))
+                  // Android 13+ shows its own copy confirmation.
+                  if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+                    Toast.makeText(context, copiedText, Toast.LENGTH_SHORT).show()
+                  }
+                  menuExpanded = false
+                })
+          }
         }
   }
 }

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -178,6 +178,8 @@
     <string name="this_node_is_trusted">This node is trusted to change the Tailnet lock configuration.</string>
     <string name="this_node_is_not_trusted">This node is not trusted to change the Tailnet lock configuration.</string>
     <string name="copy_to_clipboard">Copy to clipboard</string>
+    <string name="copy">Copy</string>
+    <string name="copied">Copied</string>
     <string name="node_key">Node key</string>
     <string name="tailnet_lock_key">Tailnet lock key</string>
     <string name="node_key_explainer">Used to sign this node from another signing device in your tailnet.</string>


### PR DESCRIPTION
Health warnings can be long-pressed to copy the full message to the clipboard.

Also adjusts the Makefile to add `-not -path "android/libs/*"` to that find, mirroring the existing `android/build/*` exclusion. The updated gomobile from yesterday now emits that *-sources.jar into android/libs/ alongside the AAR. Older gomobile did not.

https://github.com/user-attachments/assets/b0678d52-dba0-42d9-b2fe-68ac54f9de42

updates tailscale/corp#45431