### PR TITLE
android: fix LazyColumn crash from duplicate StableNodeIDs

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/ui/util/PeerHelper.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/util/PeerHelper.kt
@@ -6,6 +6,7 @@ package com.tailscale.ipn.ui.util
 import androidx.compose.ui.util.fastAny
 import com.tailscale.ipn.mdm.MDMSettings
 import com.tailscale.ipn.ui.model.Netmap
+import com.tailscale.ipn.ui.model.StableNodeID
 import com.tailscale.ipn.ui.model.Tailcfg
 import com.tailscale.ipn.ui.model.UserID
 
@@ -32,7 +33,15 @@ class PeerCategorizer {
 
     val me = netmap.currentUserProfile()
 
-    for (peer in (peers + selfNode)) {
+    val seenStableIDs = mutableSetOf<StableNodeID>()
+    // Process selfNode first so it wins if a peer somehow shares its StableID.
+    for (peer in (listOfNotNull(selfNode) + peers)) {
+
+      // A netmap containing duplicate (or empty) StableIDs would violate the unique-key
+      // invariant required by the LazyColumn, so keep only the first occurrence.
+      if (!seenStableIDs.add(peer.StableID)) {
+        continue
+      }
 
       val userId = peer.User
       val profile = netmap.userProfile(userId)

--- a/android/src/main/java/com/tailscale/ipn/ui/view/MainView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/MainView.kt
@@ -644,7 +644,9 @@ fun PeerList(
             } else {
               stickyHeader { NodesSectionHeader(peerSet = peerSet) }
             }
-            itemsWithDividers(peerSet.peers, key = { it.StableID }) { peer ->
+            // Namespace the key by userID so that a duplicate StableID across different
+            // peer groups cannot collide in the same LazyColumn.
+            itemsWithDividers(peerSet.peers, key = { "${peerSet.userID}_${it.StableID}" }) { peer ->
               ListItem(
                   modifier =
                       Modifier.combinedClickable(

--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/ExitNodePickerViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/ExitNodePickerViewModel.kt
@@ -83,7 +83,8 @@ class ExitNodePickerViewModel(private val nav: ExitNodePickerNav) : IpnViewModel
                         )
                       }
 
-              val tailnetNodes = allNodes.filter { !it.mullvad }
+              // Guard against duplicate StableIDs in the netmap; LazyColumn keys must be unique.
+              val tailnetNodes = allNodes.filter { !it.mullvad }.distinctBy { it.id }
               tailnetExitNodes.set(tailnetNodes.sortedWith { a, b -> a.label.compareTo(b.label) })
 
               val allMullvadExitNodes =

--- a/android/src/test/kotlin/com/tailcale/ipn/ui/util/PeerCategorizerTest.kt
+++ b/android/src/test/kotlin/com/tailcale/ipn/ui/util/PeerCategorizerTest.kt
@@ -1,0 +1,98 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package com.tailscale.ipn.ui.util
+
+import com.tailscale.ipn.mdm.MDMSettings
+import com.tailscale.ipn.mdm.SettingState
+import com.tailscale.ipn.ui.model.Netmap
+import com.tailscale.ipn.ui.model.Tailcfg
+import com.tailscale.ipn.ui.util.set
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class PeerCategorizerTest {
+
+  @Before
+  fun setUp() {
+    // Ensure no MDM hiding is active for these tests.
+    MDMSettings.hiddenNetworkDevices.flow.set(SettingState(emptyList(), false))
+  }
+
+  private fun node(
+      stableID: String,
+      userID: Long,
+      name: String,
+      isMullvad: Boolean = false
+  ): Tailcfg.Node {
+    return Tailcfg.Node(
+        StableID = stableID,
+        User = userID,
+        Name = name,
+        Hostinfo = Tailcfg.Hostinfo(OS = if (isMullvad) null else "linux"))
+  }
+
+  private fun userProfile(id: Long, name: String): Pair<String, Tailcfg.UserProfile> {
+    return id.toString() to Tailcfg.UserProfile(ID = id, DisplayName = name, LoginName = name)
+  }
+
+  private fun networkMap(self: Tailcfg.Node, peers: List<Tailcfg.Node>): Netmap.NetworkMap {
+    val profiles =
+        (peers + self)
+            .map { it.User }
+            .distinct()
+            .associate { userProfile(it, "user-$it") }
+    return Netmap.NetworkMap(
+        SelfNode = self,
+        Peers = peers,
+        Domain = "example.com",
+        UserProfiles = profiles,
+        TKAEnabled = false)
+  }
+
+  @Test
+  fun duplicateStableIDsAreDeduplicated() {
+    val self = node(stableID = "n-self", userID = 1, name = "self")
+    val peers =
+        listOf(
+            node(stableID = "n-dup", userID = 2, name = "first-dup"),
+            node(stableID = "n-dup", userID = 2, name = "second-dup"),
+            node(stableID = "", userID = 2, name = "empty-a"),
+            node(stableID = "", userID = 3, name = "empty-b"),
+            node(stableID = "n-unique", userID = 3, name = "unique"))
+
+    val netmap = networkMap(self, peers)
+    val categorizer = PeerCategorizer()
+    categorizer.regenerateGroupedPeers(netmap)
+
+    val allPeers = categorizer.peerSets.flatMap { it.peers }
+    val allStableIDs = allPeers.map { it.StableID }
+
+    assertEquals(4, allPeers.size)
+    assertEquals(4, allStableIDs.toSet().size)
+    assertTrue(allStableIDs.contains("n-self"))
+    assertTrue(allStableIDs.contains("n-dup"))
+    assertTrue(allStableIDs.contains(""))
+    assertTrue(allStableIDs.contains("n-unique"))
+
+    // The first duplicate should win; the second duplicate should be dropped.
+    val dupPeer = allPeers.first { it.StableID == "n-dup" }
+    assertEquals("first-dup", dupPeer.Name)
+  }
+
+  @Test
+  fun selfNodeWinsWhenPeerSharesStableID() {
+    val self = node(stableID = "n-shared", userID = 1, name = "self")
+    val peers = listOf(node(stableID = "n-shared", userID = 2, name = "other"))
+
+    val netmap = networkMap(self, peers)
+    val categorizer = PeerCategorizer()
+    categorizer.regenerateGroupedPeers(netmap)
+
+    val allPeers = categorizer.peerSets.flatMap { it.peers }
+    assertEquals(1, allPeers.size)
+    assertEquals("self", allPeers.first().Name)
+  }
+}


### PR DESCRIPTION
Fixes tailscale/tailscale#20725

The Android app can crash with `IllegalArgumentException: Key "X" was already used` when a netmap contains duplicate or otherwise non-unique StableIDs and those IDs are used as LazyColumn item keys.

Changes:
- Deduplicate peers by StableID in `PeerCategorizer`, processing `SelfNode` first so the local node wins if a peer somehow shares its StableID.
- Deduplicate tailnet exit nodes by StableID in `ExitNodePickerViewModel`.
- Namespace `MainView` peer keys per user group as defense in depth.
- Add unit tests for `PeerCategorizer` duplicate StableID handling.

Tests: added `PeerCategorizerTest`; a local Android SDK was not available in this environment so full `./gradlew testDebugUnitTest` was not executed here.
