### PR TITLE
android: bump OSS

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -55,7 +55,7 @@ android {
         // the Makefile's release-tv target rewrites this integer to end in 1 for
         // AndroidTV builds so phone (...0) and TV (...1) uploads stay
         // distinguishable in the Play Store.
-        versionCode 297642100
+        versionCode 297730490
         versionName getVersionProperty("VERSION_LONG")
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.5
 require (
 	github.com/tailscale/wireguard-go v0.0.0-20260730222847-4affce44577c
 	golang.org/x/mobile v0.0.0-20240806205939-81131f6468ab
-	tailscale.com v1.103.0-pre.0.20260804132903-ca79c1e09b4b
+	tailscale.com v1.103.0-pre.0.20260810100007-25877455e79d
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -263,5 +263,5 @@ howett.net/plist v1.0.0 h1:7CrbWYbPPO/PyNy38b2EB/+gYbjCe2DXBxgtOOZbSQM=
 howett.net/plist v1.0.0/go.mod h1:lqaXoTrLY4hg8tnEzNru53gicrbv7rrk+2xJA/7hw9g=
 software.sslmate.com/src/go-pkcs12 v0.4.0 h1:H2g08FrTvSFKUj+D309j1DPfk5APnIdAQAB8aEykJ5k=
 software.sslmate.com/src/go-pkcs12 v0.4.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=
-tailscale.com v1.103.0-pre.0.20260804132903-ca79c1e09b4b h1:SSWfXq61u0FXtclLC6rZpLS0D1qdelrz+7dH+G+c16I=
-tailscale.com v1.103.0-pre.0.20260804132903-ca79c1e09b4b/go.mod h1:kQUA0lYb/bqCJJZzShx+gqLSxggEFgXB4VDVZDzxWc8=
+tailscale.com v1.103.0-pre.0.20260810100007-25877455e79d h1:Zka6iozL923qmYERijTZrJDwA23HCZ9JEcACEt3e5q0=
+tailscale.com v1.103.0-pre.0.20260810100007-25877455e79d/go.mod h1:kQUA0lYb/bqCJJZzShx+gqLSxggEFgXB4VDVZDzxWc8=


### PR DESCRIPTION
OSS and Version updated to 1.103.0-pre.0.20260810100007-25877455e79d