### PR TITLE
android: force Client.app to initialize before executing local API requests

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/ui/localapi/Client.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/localapi/Client.kt
@@ -71,6 +71,17 @@ class Client(private val scope: CoroutineScope) {
   // Access libtailscale.Application lazily
   private val app: libtailscale.Application by lazy { App.get().getLibtailscaleApp() }
 
+  init {
+    // Force the lazy `app` property to evaluate now, at construction time, instead of
+    // waiting for something to read it. This guarantees App.get() (and therefore
+    // Request.setApp()) has run before this Client can be used to execute a Request,
+    // even if the very first caller is a background WorkManager task on a cold-started
+    // process that never otherwise touches App.get(). Without this, `app` was declared
+    // but never read anywhere in this class, so it never actually forced initialization
+    // (see #563, which added this property with that intent but never wired it up).
+    app
+  }
+
   fun start(options: Ipn.Options, responseHandler: (Result<Unit>) -> Unit) {
     val body = Json.encodeToString(options).toByteArray()
     return post(Endpoint.START, body, responseHandler = responseHandler)


### PR DESCRIPTION
### What this fixes

Fixes the `lateinit property app has not been initialized` crash at `Request.execute()`, most recently reported in tailscale/tailscale#20884, and previously in #14125 / #14314.

### Root cause

`Client` has an `app` property intended to force `App.get()` (and therefore `Request.setApp()`) to run before any local API call:

```kotlin
private val app: libtailscale.Application by lazy { App.get().getLibtailscaleApp() }
```

This property was added in #563 specifically to prevent this crash ("Lazily init app in Client to ensure that we aren't trying to make any local API calls before app has been initialized"). However, `by lazy` only evaluates on first *read* of the property, and nothing in `Client` ever reads `this.app` — none of `start()`, `status()`, `prefs()`, etc. reference it. So the property has never actually forced initialization since it was introduced; it's been dead code from the start (confirmed by checking every commit that has touched this file since #563 — none add or remove a reference to `app`).

If a `Client` is constructed and used before anything else has called `App.get()` — e.g. a WorkManager background task running on a cold-started process — `Request.execute()` reads the companion object's separate `lateinit var app` (set only via `Request.setApp()`, called from `App.startLibtailscale()`) before it's been set, and crashes.

### Fix

Add an `init` block that reads `app`, forcing the lazy initializer to run at `Client` construction time rather than never. `App.initOnce()` is `@Synchronized`, so this blocks the constructing thread until `App.get()` (and `Request.setApp()`) has fully completed, closing the race.

`Client.kt` is the only place `Request` is constructed in this codebase, so this covers every path that can reach this crash today.

This isn't a novel pattern — `Notifier.start()` already guards the equivalent case correctly:

```kotlin
if (!::app.isInitialized) {
  App.get()
}
```

This PR brings `Client` in line with that existing, correct approach used elsewhere in this codebase for the same class of problem.

### Verification

Static/manual verification only — I don't have a full Android build environment to run `make fmt-check` / `make tailscale-debug.apk` locally, so please treat CI as the source of truth for formatting and build correctness. Happy to address any CI failures.

Confirmed via `adb shell dumpsys dropbox` that this exact crash signature is currently reproducing on a shipped 1.102.2 build (Galaxy Z Fold8, and previously a Fold7 on a different Android major version), despite the crash being reported "resolved" after #563/#14125. Full crash details and device history in tailscale/tailscale#20884.
