### PR TITLE
PeerHelper: deduplicate self node in peer list to fix LazyColumn crash

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/ui/util/PeerHelper.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/util/PeerHelper.kt
@@ -32,7 +32,7 @@ class PeerCategorizer {
 
     val me = netmap.currentUserProfile()
 
-    for (peer in (peers + selfNode)) {
+    for (peer in (peers + selfNode).distinctBy { it.StableID }) {
 
       val userId = peer.User
       val profile = netmap.userProfile(userId)


### PR DESCRIPTION
## Problem

The Android app crashes immediately on launch with headscale servers:

```
java.lang.IllegalArgumentException: Key "27" was already used. If you are using LazyColumn/Row please make sure you provide a unique key for each item.
```

## Root cause

`PeerHelper.regenerateGroupedPeers()` iterates over `(peers + selfNode)`. With headscale, `selfNode` is already present in `netmap.Peers`, so it gets added twice. Both entries share the same `StableID`, which becomes a duplicate key in `MainView`'s `LazyColumn`.

## Fix

`distinctBy { it.StableID }` on the combined list before iterating.

## Testing

Verified working on Raspberry Pi 4 running LineageOS TV, authenticated against a headscale server. Before fix: crash on every launch. After fix: UI loads and functions correctly.

## Refs

- Closes #20725
- Ref #832 (same fix, closed by author before merge)
