### PR TITLE
android: fix peer-list LazyColumn crash and trust self-signed headscale CA

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,11 +4,9 @@ buildscript {
     ext.accompanist_version = "0.34.0"
 
     repositories {
-        google()
-        mavenCentral()
-        maven {
-            url = uri("https://plugins.gradle.org/m2/")
-        }
+        maven { url = uri("https://maven.aliyun.com/repository/google") }
+        maven { url = uri("https://maven.aliyun.com/repository/central") }
+        maven { url = uri("https://maven.aliyun.com/repository/gradle-plugin") }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.13.0'
@@ -19,8 +17,8 @@ buildscript {
 }
 
 repositories {
-    google()
-    mavenCentral()
+    maven { url = uri("https://maven.aliyun.com/repository/google") }
+    maven { url = uri("https://maven.aliyun.com/repository/central") }
     flatDir {
         dirs 'libs'
     }

--- a/android/src/main/java/com/tailscale/ipn/ui/util/PeerHelper.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/util/PeerHelper.kt
@@ -6,6 +6,7 @@ package com.tailscale.ipn.ui.util
 import androidx.compose.ui.util.fastAny
 import com.tailscale.ipn.mdm.MDMSettings
 import com.tailscale.ipn.ui.model.Netmap
+import com.tailscale.ipn.ui.model.StableNodeID
 import com.tailscale.ipn.ui.model.Tailcfg
 import com.tailscale.ipn.ui.model.UserID
 
@@ -32,7 +33,15 @@ class PeerCategorizer {
 
     val me = netmap.currentUserProfile()
 
-    for (peer in (peers + selfNode)) {
+    val seenStableIDs = mutableSetOf<StableNodeID>()
+    // Process selfNode first so it wins if a peer somehow shares its StableID.
+    for (peer in (listOfNotNull(selfNode) + peers)) {
+
+      // A netmap containing duplicate (or empty) StableIDs would violate the unique-key
+      // invariant required by the LazyColumn, so keep only the first occurrence.
+      if (!seenStableIDs.add(peer.StableID)) {
+        continue
+      }
 
       val userId = peer.User
       val profile = netmap.userProfile(userId)

--- a/android/src/main/java/com/tailscale/ipn/ui/view/MainView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/MainView.kt
@@ -644,7 +644,9 @@ fun PeerList(
             } else {
               stickyHeader { NodesSectionHeader(peerSet = peerSet) }
             }
-            itemsWithDividers(peerSet.peers, key = { it.StableID }) { peer ->
+            // Namespace the key by userID so that a duplicate StableID across different
+            // peer groups cannot collide in the same LazyColumn.
+            itemsWithDividers(peerSet.peers, key = { "${peerSet.userID}_${it.StableID}" }) { peer ->
               ListItem(
                   modifier =
                       Modifier.combinedClickable(

--- a/android/src/main/java/com/tailscale/ipn/ui/viewModel/ExitNodePickerViewModel.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/viewModel/ExitNodePickerViewModel.kt
@@ -83,7 +83,8 @@ class ExitNodePickerViewModel(private val nav: ExitNodePickerNav) : IpnViewModel
                         )
                       }
 
-              val tailnetNodes = allNodes.filter { !it.mullvad }
+              // Guard against duplicate StableIDs in the netmap; LazyColumn keys must be unique.
+              val tailnetNodes = allNodes.filter { !it.mullvad }.distinctBy { it.id }
               tailnetExitNodes.set(tailnetNodes.sortedWith { a, b -> a.label.compareTo(b.label) })
 
               val allMullvadExitNodes =

--- a/android/src/test/kotlin/com/tailscale/ipn/ui/util/PeerCategorizerTest.kt
+++ b/android/src/test/kotlin/com/tailscale/ipn/ui/util/PeerCategorizerTest.kt
@@ -1,0 +1,97 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package com.tailscale.ipn.ui.util
+
+import com.tailscale.ipn.mdm.MDMSettings
+import com.tailscale.ipn.mdm.SettingState
+import com.tailscale.ipn.ui.model.Netmap
+import com.tailscale.ipn.ui.model.Tailcfg
+import com.tailscale.ipn.ui.util.set
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class PeerCategorizerTest {
+
+  @Before
+  fun setUp() {
+    // Ensure no MDM hiding is active for these tests.
+    MDMSettings.hiddenNetworkDevices.flow.set(SettingState(emptyList(), false))
+  }
+
+  private fun node(
+      stableID: String,
+      userID: Long,
+      name: String,
+      isMullvad: Boolean = false
+  ): Tailcfg.Node {
+    return Tailcfg.Node(
+        StableID = stableID,
+        User = userID,
+        Name = name,
+        Hostinfo = Tailcfg.Hostinfo(OS = if (isMullvad) null else "linux"))
+  }
+
+  private fun userProfile(id: Long, name: String): Pair<String, Tailcfg.UserProfile> {
+    return id.toString() to Tailcfg.UserProfile(ID = id, DisplayName = name, LoginName = name)
+  }
+
+  private fun networkMap(self: Tailcfg.Node, peers: List<Tailcfg.Node>): Netmap.NetworkMap {
+    val profiles =
+        (peers + self)
+            .map { it.User }
+            .distinct()
+            .associate { userProfile(it, "user-$it") }
+    return Netmap.NetworkMap(
+        SelfNode = self,
+        Peers = peers,
+        Domain = "example.com",
+        UserProfiles = profiles,
+        TKAEnabled = false)
+  }
+
+  @Test
+  fun duplicateStableIDsAreDeduplicated() {
+    val self = node(stableID = "n-self", userID = 1, name = "self")
+    val peers =
+        listOf(
+            node(stableID = "n-dup", userID = 2, name = "first-dup"),
+            node(stableID = "n-dup", userID = 2, name = "second-dup"),
+            node(stableID = "", userID = 2, name = "empty-a"),
+            node(stableID = "", userID = 3, name = "empty-b"),
+            node(stableID = "n-unique", userID = 3, name = "unique"))
+
+    val netmap = networkMap(self, peers)
+    val categorizer = PeerCategorizer()
+    categorizer.regenerateGroupedPeers(netmap)
+
+    val allPeers = categorizer.peerSets.flatMap { it.peers }
+    val allStableIDs = allPeers.map { it.StableID }
+
+    assertEquals(4, allPeers.size)
+    assertEquals(4, allStableIDs.toSet().size)
+    assertTrue(allStableIDs.contains("n-self"))
+    assertTrue(allStableIDs.contains("n-dup"))
+    assertTrue(allStableIDs.contains(""))
+    assertTrue(allStableIDs.contains("n-unique"))
+
+    val dupPeer = allPeers.first { it.StableID == "n-dup" }
+    assertEquals("first-dup", dupPeer.Name)
+  }
+
+  @Test
+  fun selfNodeWinsWhenPeerSharesStableID() {
+    val self = node(stableID = "n-shared", userID = 1, name = "self")
+    val peers = listOf(node(stableID = "n-shared", userID = 2, name = "other"))
+
+    val netmap = networkMap(self, peers)
+    val categorizer = PeerCategorizer()
+    categorizer.regenerateGroupedPeers(netmap)
+
+    val allPeers = categorizer.peerSets.flatMap { it.peers }
+    assertEquals(1, allPeers.size)
+    assertEquals("self", allPeers.first().Name)
+  }
+}

--- a/libtailscale/backend.go
+++ b/libtailscale/backend.go
@@ -342,6 +342,7 @@ func (a *App) newBackend(dataDir string, appCtx AppContext, store *stateStore,
 		Metrics:        sys.UserMetricsRegistry(),
 		DriveForLocal:  driveimpl.NewFileSystemForLocal(logf),
 		EventBus:       sys.Bus.Get(),
+		ExtraRootCAs:   sys.ExtraRootCAs,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("runBackend: NewUserspaceEngine: %v", err)


### PR DESCRIPTION
## Summary

Fixes two issues affecting the **1.102.x** release line when used with a self-hosted **headscale** control server (custom `ControlURL`, self-signed TLS).

1. **App crash on launch** — the peer list (Compose `LazyColumn`) threw `IllegalArgumentException: Key "X" was already used`.
2. **Control-plane / DERP TLS handshake failure** — the Go engine could not trust the headscale self-signed CA, so the node could register but could not establish control-plane or DERP (relay) connections, leaving health warnings `tls-connection-failed` and `no-derp-connection`.

## Root cause

### Crash: duplicate StableIDs in the peer list

When connecting to a headscale/custom control server, the netmap may include the **self node (or duplicate entries) inside `Peers`**. `PeerCategorizer.regenerateGroupedPeers` iterates `(peers + selfNode)`, so the self node could be added twice and two peers could share the same `StableID`. Compose `LazyColumn` requires a unique key per item, so the duplicate key triggered the crash.

### TLS: `ExtraRootCAs` not plumbed to DERP

`App.getUserCACertsPEM()` feeds user-installed CAs into `tsd.System.ExtraRootCAs`, which `ipnlocal` uses for the **control client**. However that path was **not passed to `wgengine.Config`**, so `magicsock` fell back to the system root pool for **DERP** connections and rejected the self-signed CA (`x509: certificate signed by unknown authority`).

## Changes

- **`android/src/main/java/com/tailscale/ipn/ui/util/PeerHelper.kt`**
  - Deduplicate peers by `StableID` in `regenerateGroupedPeers`, processing `selfNode` first so it wins if a peer somehow shares its `StableID`.
- **`android/src/main/java/com/tailscale/ipn/ui/view/MainView.kt`**
  - Namespace peer-list item keys by `userID` so a duplicate `StableID` across different user groups cannot collide.
- **`android/src/main/java/com/tailscale/ipn/ui/viewModel/ExitNodePickerViewModel.kt`**
  - Deduplicate exit nodes by `id`.
- **`libtailscale/backend.go`**
  - Wire `ExtraRootCAs: sys.ExtraRootCAs` into `wgengine.Config` so both control-plane and DERP TLS trust the configured CA.
- **`android/src/test/kotlin/com/tailscale/ipn/ui/util/PeerCategorizerTest.kt`**
  - New unit tests covering duplicate and empty `StableID`s.
- **`android/build.gradle`**
  - Repository mirror switch for build speed (non-functional; can be dropped if undesired).

## Testing / verification

- Unit test `PeerCategorizerTest` (2 cases) passes.
- Debug APK built successfully (`BUILD SUCCESSFUL`, `libtailscale.aar` + `assembleDebug`).
- Verified on a Mate 40 Pro (HarmonyOS 4.2.0) with a self-hosted headscale server:
  - Peer list renders without crashing.
  - Control-plane connection succeeds.
  - DERP (`derp-999`, CN) connects and the `no-derp-connection` / `tls-connection-failed` warnings clear.
- The headscale CA is installed as a system certificate; the app no longer bundles an embedded cert.

## Notes for reviewers

- The Gradle repository mirror change (`android/build.gradle`) was added only to make builds feasible in a proxied environment and can be reverted if you prefer to keep upstream Maven/Google repos.
- Applies cleanly on `release-branch/1.102` (HEAD `aea8f60`).
