### PR TITLE
android: plumb ExtraRootCAs into wgengine so DERP trusts user/system CA

### DIFF
--- a/libtailscale/backend.go
+++ b/libtailscale/backend.go
@@ -342,6 +342,7 @@ func (a *App) newBackend(dataDir string, appCtx AppContext, store *stateStore,
 		Metrics:        sys.UserMetricsRegistry(),
 		DriveForLocal:  driveimpl.NewFileSystemForLocal(logf),
 		EventBus:       sys.Bus.Get(),
+		ExtraRootCAs:   sys.ExtraRootCAs,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("runBackend: NewUserspaceEngine: %v", err)


### PR DESCRIPTION
## Summary

Allows the Go engine (libtailscale) to trust a custom self-signed CA for **DERP** relay connections when it is provided as a user-installed CA (or via `App.getUserCACertsPEM()`).

The Android app already trusts such a CA for the **control client** (`tsd.System.ExtraRootCAs` is passed to `ipnlocal`). However that pool was **not** forwarded to `wgengine.Config`, so `magicsock` fell back to the **system root pool** for DERP connections and rejected the CA:

```
derphttp.Client.Recv: connecting to derp-999 ...
x509: certificate signed by unknown authority
```

This left the health warnings `tls-connection-failed` and `no-derp-connection` even though the control plane itself connected fine.

## Change

- **`libtailscale/backend.go`**
  - Wire `ExtraRootCAs: sys.ExtraRootCAs` into `wgengine.Config` so DERP TLS uses the same trust pool as the control client (`userspace.go` -> `magicsock`).

## Notes for reviewers

- **How the CA is trusted**: `App.getUserCACertsPEM()` returns user-installed CA certs (AndroidCAStore accounts with a `user:` prefix). When the CA is installed this way, `sys.ExtraRootCAs` is non-nil and this change makes DERP trust it. When the CA is instead installed at the **system** level, `getUserCACertsPEM()` returns empty / `ExtraRootCAs` stays nil, and DERP relies on the engine's native `SystemCertPool()` — this change is then a no-op.
- Applies cleanly on `release-branch/1.102` (HEAD `aea8f60`).

## Testing / verification

- Built `libtailscale.aar` + debug APK successfully.
- Verified on a Mate 40 Pro (HarmonyOS 4.2.0) against a self-hosted headscale server: after the CA is trusted, `no-derp-connection` / `tls-connection-failed` clear and DERP (`derp-999`, CN) connects.

Updates #20961