### PR TITLE
android: bound split tunnel app icons

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/ui/view/SplitTunnelAppPickerView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/SplitTunnelAppPickerView.kt
@@ -8,8 +8,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -29,9 +29,11 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -56,6 +58,8 @@ fun SplitTunnelAppPickerView(
   val mdmExcludedPackages by model.mdmExcludedPackages.collectAsState()
   val showHeaderMenu by model.showHeaderMenu.collectAsState()
   val showSwitchDialog by model.showSwitchDialog.collectAsState()
+  val iconSize = 40.dp
+  val iconSizePx = with(LocalDensity.current) { iconSize.roundToPx() }
 
   if (showSwitchDialog) {
     SwitchAlertDialog(
@@ -133,17 +137,21 @@ fun SplitTunnelAppPickerView(
           }
         } else {
           items(installedApps, key = { it.packageName }) { app ->
+            val icon =
+                remember(app.packageName, iconSizePx) {
+                  model.installedAppsManager.packageManager
+                      .getApplicationIcon(app.packageName)
+                      .toBitmap(width = iconSizePx, height = iconSizePx)
+                      .asImageBitmap()
+                }
+
             ListItem(
                 headlineContent = { Text(app.name, fontWeight = FontWeight.SemiBold) },
                 leadingContent = {
                   Image(
-                      bitmap =
-                          model.installedAppsManager.packageManager
-                              .getApplicationIcon(app.packageName)
-                              .toBitmap()
-                              .asImageBitmap(),
+                      bitmap = icon,
                       contentDescription = null,
-                      modifier = Modifier.width(40.dp).height(40.dp),
+                      modifier = Modifier.size(iconSize),
                   )
                 },
                 supportingContent = {


### PR DESCRIPTION
This rasterizes app icons at their displayed size instead of instrinsic drawable size to prevent draw crashes. We also remember the bitmap so that icons aren't reloaded and converted on every recomposition

Fixes tailscale/corp#47360