### PR TITLE
android: bump OSS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.27.0
 require (
 	github.com/tailscale/wireguard-go v0.0.0-20260821191448-23d18d66172c
 	golang.org/x/mobile v0.0.0-20240806205939-81131f6468ab
-	tailscale.com v1.103.0-pre.0.20260827214226-1e69418c298b
+	tailscale.com v1.103.0-pre.0.20260831171553-d9cc55e33b4a
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -263,5 +263,5 @@ howett.net/plist v1.0.0 h1:7CrbWYbPPO/PyNy38b2EB/+gYbjCe2DXBxgtOOZbSQM=
 howett.net/plist v1.0.0/go.mod h1:lqaXoTrLY4hg8tnEzNru53gicrbv7rrk+2xJA/7hw9g=
 software.sslmate.com/src/go-pkcs12 v0.4.0 h1:H2g08FrTvSFKUj+D309j1DPfk5APnIdAQAB8aEykJ5k=
 software.sslmate.com/src/go-pkcs12 v0.4.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=
-tailscale.com v1.103.0-pre.0.20260827214226-1e69418c298b h1:Z2kFxtS0kzGYrB6UKJWCYOKSsClffwPRBmrTs6C7SXg=
-tailscale.com v1.103.0-pre.0.20260827214226-1e69418c298b/go.mod h1:0FUeNgU+WylKFtsg4LOZQxceO16WyN9YjvrxmUiilbs=
+tailscale.com v1.103.0-pre.0.20260831171553-d9cc55e33b4a h1:xlWOoWkscFoYBLjmOLQZkZ1h5Jcd5Ir/HXPzerjZdoQ=
+tailscale.com v1.103.0-pre.0.20260831171553-d9cc55e33b4a/go.mod h1:0FUeNgU+WylKFtsg4LOZQxceO16WyN9YjvrxmUiilbs=


### PR DESCRIPTION
OSS and Version updated to 1.103.165-td9cc55e33-g7e35a62f6