### PR TITLE
android: fix exit-node intent worker completion

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/UseExitNodeWorker.kt
+++ b/android/src/main/java/com/tailscale/ipn/UseExitNodeWorker.kt
@@ -13,9 +13,37 @@ import com.tailscale.ipn.UninitializedApp.Companion.STATUS_CHANNEL_ID
 import com.tailscale.ipn.ui.localapi.Client
 import com.tailscale.ipn.ui.model.Ipn
 import com.tailscale.ipn.ui.notifier.Notifier
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.coroutines.resume
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
+
+private const val EDIT_PREFS_TIMEOUT_MILLIS = 35_000L
+
+internal suspend fun <T> awaitSingleCallback(
+    register: ((kotlin.Result<T>) -> Unit) -> Unit
+): kotlin.Result<T> = suspendCancellableCoroutine { continuation ->
+  val completed = AtomicBoolean(false)
+  continuation.invokeOnCancellation { completed.set(true) }
+  register { result ->
+    if (completed.compareAndSet(false, true)) {
+      continuation.resume(result)
+    }
+  }
+}
+
+internal fun buildExitNodePrefs(exitNodeId: String?, allowLanAccess: Boolean): Ipn.MaskedPrefs =
+    Ipn.MaskedPrefs().apply {
+      ExitNodeID = exitNodeId
+      ExitNodeAllowLANAccess = allowLanAccess
+    }
+
+internal fun exitNodePrefsMatch(
+    prefs: Ipn.Prefs,
+    exitNodeId: String?,
+    allowLanAccess: Boolean
+): Boolean = prefs.activeExitNodeID == exitNodeId && prefs.ExitNodeAllowLANAccess == allowLanAccess
 
 class UseExitNodeWorker(appContext: Context, workerParams: WorkerParameters) :
     CoroutineWorker(appContext, workerParams) {
@@ -56,24 +84,22 @@ class UseExitNodeWorker(appContext: Context, workerParams: WorkerParameters) :
           }
 
       val allowLanAccess = inputData.getBoolean(ALLOW_LAN_ACCESS, false)
-      val prefsOut = Ipn.MaskedPrefs()
-      prefsOut.ExitNodeID = exitNodeId
-      prefsOut.ExitNodeAllowLANAccess = allowLanAccess
-
-      val scope = CoroutineScope(Dispatchers.Default + Job())
-      var result: String? = null
-      Client(scope).editPrefs(prefsOut) {
-        result =
-            if (it.isFailure) {
-              it.exceptionOrNull()?.message
-            } else {
-              null
+      val prefsOut = buildExitNodePrefs(exitNodeId, allowLanAccess)
+      val editResult =
+          withTimeoutOrNull(EDIT_PREFS_TIMEOUT_MILLIS) {
+            coroutineScope {
+              awaitSingleCallback<Ipn.Prefs> { done -> Client(this).editPrefs(prefsOut, done) }
             }
+          } ?: return app.getString(R.string.use_exit_node_intent_timed_out)
+
+      val appliedPrefs =
+          editResult.getOrElse {
+            return it.message ?: app.getString(R.string.use_exit_node_intent_unknown_error)
+          }
+      if (!exitNodePrefsMatch(appliedPrefs, exitNodeId, allowLanAccess)) {
+        return app.getString(R.string.use_exit_node_intent_not_applied)
       }
-
-      scope.coroutineContext[Job]?.join()
-
-      return result
+      return null
     }
 
     val result = runAndGetResult()

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -287,6 +287,9 @@
     <string name="multiple_peers_with_name_found">Multiple peers with name %1$s found</string>
     <string name="peer_with_name_is_not_an_exit_node">Peer with name %1$s is not an exit node</string>
     <string name="use_exit_node_intent_failed">Use Exit Node Intent Failed</string>
+    <string name="use_exit_node_intent_timed_out">Exit node change timed out</string>
+    <string name="use_exit_node_intent_not_applied">Exit node change was not applied</string>
+    <string name="use_exit_node_intent_unknown_error">Exit node change failed</string>
 
     <!-- Strings for the IPNReceiver -->
     <string name="title_connection_failed">Tailscale Connection Failed</string>

--- a/android/src/test/kotlin/com/tailscale/ipn/UseExitNodeWorkerTest.kt
+++ b/android/src/test/kotlin/com/tailscale/ipn/UseExitNodeWorkerTest.kt
@@ -1,0 +1,118 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package com.tailscale.ipn
+
+import com.tailscale.ipn.ui.model.Ipn
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UseExitNodeWorkerTest {
+  @Test
+  fun callbackBridgeWaitsForCallback() = runTest {
+    lateinit var callback: (Result<String>) -> Unit
+    val result = async { awaitSingleCallback<String> { callback = it } }
+
+    runCurrent()
+    assertFalse(result.isCompleted)
+
+    callback(Result.success("done"))
+    runCurrent()
+    assertEquals("done", result.await().getOrThrow())
+  }
+
+  @Test
+  fun callbackBridgeReturnsFailure() = runTest {
+    lateinit var callback: (Result<String>) -> Unit
+    val error = IllegalStateException("failed")
+    val result = async { awaitSingleCallback<String> { callback = it } }
+
+    runCurrent()
+    callback(Result.failure(error))
+    runCurrent()
+
+    assertSame(error, result.await().exceptionOrNull())
+  }
+
+  @Test
+  fun callbackBridgeCanBeBoundedByTimeout() = runTest {
+    val result = withTimeoutOrNull(100) { awaitSingleCallback<String> {} }
+
+    assertNull(result)
+  }
+
+  @Test
+  fun parentCancellationPropagates() = runTest {
+    lateinit var callback: (Result<String>) -> Unit
+    val job = launch { awaitSingleCallback<String> { callback = it } }
+
+    runCurrent()
+    job.cancel()
+    runCurrent()
+    assertTrue(job.isCancelled)
+
+    callback(Result.success("late"))
+    runCurrent()
+    assertTrue(job.isCancelled)
+  }
+
+  @Test
+  fun duplicateCallbackUsesFirstResult() = runTest {
+    lateinit var callback: (Result<String>) -> Unit
+    val result = async { awaitSingleCallback<String> { callback = it } }
+
+    runCurrent()
+    callback(Result.success("first"))
+    callback(Result.success("second"))
+    runCurrent()
+
+    assertEquals("first", result.await().getOrThrow())
+  }
+
+  @Test
+  fun buildExitNodePrefsSetsExactMask() {
+    val prefs = buildExitNodePrefs("node-1", true)
+
+    assertEquals("node-1", prefs.ExitNodeID)
+    assertEquals(true, prefs.ExitNodeIDSet)
+    assertEquals(true, prefs.ExitNodeAllowLANAccess)
+    assertEquals(true, prefs.ExitNodeAllowLANAccessSet)
+  }
+
+  @Test
+  fun buildExitNodePrefsClearsWithSetBits() {
+    val prefs = buildExitNodePrefs(null, false)
+
+    assertNull(prefs.ExitNodeID)
+    assertEquals(true, prefs.ExitNodeIDSet)
+    assertEquals(false, prefs.ExitNodeAllowLANAccess)
+    assertEquals(true, prefs.ExitNodeAllowLANAccessSet)
+  }
+
+  @Test
+  fun returnedPrefsMustMatchRequestedValues() {
+    val applied = Ipn.Prefs(ExitNodeID = "node-1", ExitNodeAllowLANAccess = true)
+
+    assertTrue(exitNodePrefsMatch(applied, "node-1", true))
+    assertFalse(exitNodePrefsMatch(applied, "node-2", true))
+    assertFalse(exitNodePrefsMatch(applied, "node-1", false))
+  }
+
+  @Test
+  fun returnedPrefsTreatsEmptyExitNodeAsCleared() {
+    val applied = Ipn.Prefs(ExitNodeID = "", ExitNodeAllowLANAccess = false)
+
+    assertTrue(exitNodePrefsMatch(applied, null, false))
+  }
+}


### PR DESCRIPTION
## Summary

- await the `editPrefs` callback inside the worker-owned coroutine scope
- bound the LocalAPI edit and verify the returned exit-node preferences
- add focused tests for completion, failure, timeout, cancellation, duplicate callbacks, preference masks, and returned-state mismatch

## Problem

`UseExitNodeWorker` creates a detached `CoroutineScope(Dispatchers.Default + Job())`, starts `editPrefs`, and then joins the root `Job`. A standalone root `Job` does not complete when its children finish, and nothing explicitly completes it. The non-completing worker can be stopped or rescheduled by WorkManager, consistent with the delayed preference replays reported in tailscale/tailscale#17960.

This change bridges the one-shot callback with structured cancellation, keeps the LocalAPI request under the worker lifecycle, applies a 35-second bound over the existing 30-second LocalAPI timeout, and reports success only when the returned effective exit-node ID and LAN setting match the request.

Cancellation prevents late callback completion but cannot undo a preferences PATCH already accepted by the backend.

## Testing

- `make fmt-check`
- `make test`
- `make go-test`
- `./tool/go mod tidy` with a clean diff
- `make tailscale-debug.apk`

## Related work

Fixes tailscale/tailscale#12720.
Fixes tailscale/tailscale#17960.

PR #793 also changes this worker as part of a broader Android 11 foreground-work change. This PR isolates the callback lifecycle correction and its regression tests. It does not add receiver cached-state shortcuts or foreground notifications.

PR #810 addresses a separate cold-start LocalAPI initialization crash. This change does not modify cold-start initialization.
