### PR TITLE
android: include tailscale in split tunnel allowlist

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/IPNService.kt
+++ b/android/src/main/java/com/tailscale/ipn/IPNService.kt
@@ -209,15 +209,19 @@ open class IPNService : VpnService(), libtailscale.IPNService {
       TSLog.d(TAG, "Application packages were set by user: $packagesList")
     }
 
+    packagesList =
+        packagesForVpnBuilder(
+            packagesList = packagesList,
+            allowPackages = allowPackages,
+            tailscalePackageName = UninitializedApp.get().packageName,
+            builtInDisallowedPackages = UninitializedApp.get().builtInDisallowedPackageNames)
+
     if (allowPackages) {
       for (packageName in packagesList) {
         TSLog.d(TAG, "Including app: $packageName")
         allowApp(b, packageName)
       }
     } else {
-      // Make sure to also exclude hard-coded apps that are known to cause issues
-      packagesList += UninitializedApp.get().builtInDisallowedPackageNames
-
       for (packageName in packagesList) {
         TSLog.d(TAG, "Disallowing app: $packageName")
         disallowApp(b, packageName)
@@ -234,3 +238,15 @@ open class IPNService : VpnService(), libtailscale.IPNService {
     const val ACTION_START_FOREGROUND_ONLY = "com.tailscale.ipn.START_FOREGROUND_ONLY"
   }
 }
+
+internal fun packagesForVpnBuilder(
+    packagesList: List<String>,
+    allowPackages: Boolean,
+    tailscalePackageName: String,
+    builtInDisallowedPackages: List<String>,
+): List<String> =
+    if (allowPackages) {
+      packagesList + tailscalePackageName
+    } else {
+      packagesList + builtInDisallowedPackages
+    }

--- a/android/src/test/kotlin/com/tailcale/ipn/IPNServiceTest.kt
+++ b/android/src/test/kotlin/com/tailcale/ipn/IPNServiceTest.kt
@@ -1,0 +1,33 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package com.tailscale.ipn
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class IPNServiceTest {
+  @Test
+  fun allowedPackagesIncludeTailscale() {
+    val packages =
+        packagesForVpnBuilder(
+            packagesList = listOf("com.termux"),
+            allowPackages = true,
+            tailscalePackageName = "com.tailscale.ipn",
+            builtInDisallowedPackages = emptyList())
+
+    assertEquals(listOf("com.termux", "com.tailscale.ipn"), packages)
+  }
+
+  @Test
+  fun excludedPackagesIncludeBuiltInDisallowedPackages() {
+    val packages =
+        packagesForVpnBuilder(
+            packagesList = listOf("com.example.excluded"),
+            allowPackages = false,
+            tailscalePackageName = "com.tailscale.ipn",
+            builtInDisallowedPackages = listOf("com.example.builtin"))
+
+    assertEquals(listOf("com.example.excluded", "com.example.builtin"), packages)
+  }
+}


### PR DESCRIPTION
This adds tailscale to the allowlist when split tunneling is configured in include mode. Without this, included apps lose access to tailscale DNS because the tailscale process is excluded from the vpn.

Tested manually with an included app against a dns record that is onlly resolvable through a tailnet dns servier, and verified the record resolves in allowlist mode and confirmed the query reaches the tailnet resolver over tailscale

Fixes tailscale/tailscale#20978