### PR TITLE
android: prefer validated networks, and set them

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/IPNService.kt
+++ b/android/src/main/java/com/tailscale/ipn/IPNService.kt
@@ -5,6 +5,7 @@ package com.tailscale.ipn
 import android.app.PendingIntent
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Network
 import android.net.VpnService
 import android.os.Build
 import android.system.OsConstants
@@ -38,6 +39,10 @@ open class IPNService : VpnService(), libtailscale.IPNService {
     super.onCreate()
     // grab app to make sure it initializes
     app = App.get()
+
+    NetworkChangeCallback.setUnderlyingNetworkListener { network ->
+      updateUnderlyingNetwork(network)
+    }
   }
 
   override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int =
@@ -109,6 +114,7 @@ open class IPNService : VpnService(), libtailscale.IPNService {
   }
 
   override fun onDestroy() {
+    NetworkChangeCallback.setUnderlyingNetworkListener(null)
     close()
     updateVpnStatus(false)
     super.onDestroy()
@@ -126,6 +132,15 @@ open class IPNService : VpnService(), libtailscale.IPNService {
 
   private fun setVpnPrepared(isPrepared: Boolean) {
     app.getAppScopedViewModel().setVpnPrepared(isPrepared)
+  }
+
+  private fun updateUnderlyingNetwork(network: Network?) {
+    val networks = network?.let { arrayOf(it) } ?: emptyArray()
+    if (!setUnderlyingNetworks(networks)) {
+      TSLog.w(TAG, "Failed to set underlying network: $network")
+    } else {
+      TSLog.d(TAG, "Set underlying network: $network")
+    }
   }
 
   private fun showForegroundNotification(
@@ -180,7 +195,9 @@ open class IPNService : VpnService(), libtailscale.IPNService {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
       b.setMetered(false) // Inherit the metered status from the underlying networks.
     }
-    b.setUnderlyingNetworks(null) // Use all available networks.
+
+    val underlyingNetwork = NetworkChangeCallback.cachedDefaultNetwork
+    b.setUnderlyingNetworks(underlyingNetwork?.let { arrayOf(it) } ?: emptyArray())
 
     val mdmAllowed =
         MDMSettings.includedPackages.flow.value.value?.split(",")?.map { it.trim() } ?: emptyList()

--- a/android/src/main/java/com/tailscale/ipn/NetworkChangeCallback.kt
+++ b/android/src/main/java/com/tailscale/ipn/NetworkChangeCallback.kt
@@ -13,6 +13,34 @@ import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 import libtailscale.Libtailscale
 
+internal data class NetworkCandidate<T>(
+    val value: T,
+    val internet: Boolean,
+    val notVpn: Boolean,
+    val validated: Boolean,
+    val hasDns: Boolean,
+    val nonMetered: Boolean,
+)
+
+internal fun <T> pickPreferredNetwork(candidates: List<NetworkCandidate<T>>): T? {
+  fun pick(requireValidated: Boolean, requireDNS: Boolean): T? {
+    val matching =
+        candidates.filter {
+          it.internet &&
+              it.notVpn &&
+              (!requireValidated || it.validated) &&
+              (!requireDNS || it.hasDns)
+        }
+
+    return matching.firstOrNull { it.nonMetered }?.value ?: matching.firstOrNull()?.value
+  }
+
+  return pick(requireValidated = true, requireDNS = true)
+      ?: pick(requireValidated = true, requireDNS = false)
+      ?: pick(requireValidated = false, requireDNS = true)
+      ?: pick(requireValidated = false, requireDNS = false)
+}
+
 object NetworkChangeCallback {
 
   private const val TAG = "NetworkChangeCallback"
@@ -36,6 +64,12 @@ object NetworkChangeCallback {
   @Volatile
   var cachedDefaultInterfaceName: String? = null
     private set
+
+  @Volatile private var underlyingNetworkListener: ((Network?) -> Unit)? = null
+
+  fun setUnderlyingNetworkListener(listener: ((Network?) -> Unit)?) {
+    underlyingNetworkListener = listener
+  }
 
   // monitorDnsChanges sets up a network callback to monitor changes to the
   // system's network state and update the DNS configuration when interfaces
@@ -104,60 +138,38 @@ object NetworkChangeCallback {
         })
   }
 
-  // pickNonMetered returns the first non-metered network in the list of
-  // networks, or the first network if none are non-metered.
-  private fun pickNonMetered(networks: Map<Network, NetworkInfo>): Network? {
-    for ((network, info) in networks) {
-      if (info.caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)) {
-        return network
-      }
-    }
-    return networks.keys.firstOrNull()
-  }
-
   // pickDefaultNetwork returns a non-VPN network to use as the 'default'
   // network; one that is used as a gateway to the internet and from which we
   // obtain our DNS servers.
+  //
+  // Networks are preferred in this order:
+  //   1. VALIDATED + INTERNET + NOT_VPN + DNS
+  //   2. VALIDATED + INTERNET + NOT_VPN
+  //   3. INTERNET + NOT_VPN + DNS
+  //   4. INTERNET + NOT_VPN
+  //   5. null
+  //
+  // Within each group, prefer a non-metered network. VALIDATED is preferred,
+  // but not required, because per
+  // https://developer.android.com/develop/connectivity/network-ops/reading-network-state,
+  // newly available networks may be usable before Android has finished validating them.
   private fun pickDefaultNetwork(): Network? {
-    // Filter the list of all networks to those that have the INTERNET
-    // capability, are not VPNs, and have a non-zero number of DNS servers
-    // available.
-    val networks =
-        activeNetworks.filter { (_, info) ->
-          info.caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
-              info.caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN) &&
-              info.linkProps.dnsServers.isNotEmpty()
-        }
-
-    // If we have one; just return it; otherwise, prefer networks that are also
-    // not metered (i.e. cell modems).
-    val nonMeteredNetwork = pickNonMetered(networks)
-    if (nonMeteredNetwork != null) {
-      return nonMeteredNetwork
-    }
-
-    // Okay, less good; just return the first network that has the INTERNET and
-    // NOT_VPN capabilities; even though this interface doesn't have any DNS
-    // servers set, we'll use our DNS fallback servers to make queries. It's
-    // strictly better to return an interface + use the DNS fallback servers
-    // than to return nothing and not be able to route traffic.
-    for ((network, info) in activeNetworks) {
-      if (info.caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
-          info.caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN)) {
-        Log.w(TAG, "no networks with DNS; falling back to first network $network")
-        return network
-      }
-    }
-
-    // Otherwise, return nothing; we don't want to return a VPN network since
-    // it could result in a routing loop, and a non-INTERNET network isn't
-    // helpful.
-    Log.w(TAG, "no networks available to pick default network")
-    return null
+    return pickPreferredNetwork(
+        activeNetworks.map { (network, info) ->
+          NetworkCandidate(
+              value = network,
+              internet = info.caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET),
+              notVpn = info.caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN),
+              validated = info.caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED),
+              hasDns = info.linkProps.dnsServers.isNotEmpty(),
+              nonMetered = info.caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED),
+          )
+        })
   }
 
   // Update cached default network + log interface name.
   private fun recomputeDefaultNetworkLocked(why: String) {
+    val oldNetwork = cachedDefaultNetwork
     val newNetwork = pickDefaultNetwork()
     cachedDefaultNetwork = newNetwork
 
@@ -167,6 +179,10 @@ object NetworkChangeCallback {
 
     TSLog.d(
         TAG, "$why: cachedDefaultNetwork=$newNetwork iface=${cachedDefaultInterfaceName ?: "none"}")
+
+    if (newNetwork != oldNetwork) {
+      underlyingNetworkListener?.invoke(newNetwork)
+    }
   }
 
   // maybeUpdateDNSConfig will maybe update our DNS configuration based on the

--- a/android/src/test/kotlin/com/tailcale/ipn/NetworkChangeCallbackTest.kt
+++ b/android/src/test/kotlin/com/tailcale/ipn/NetworkChangeCallbackTest.kt
@@ -1,0 +1,120 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package com.tailscale.ipn
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class NetworkChangeCallbackTest {
+  @Test
+  fun prefersValidatedNetworkWithDns() {
+    val result =
+        pickPreferredNetwork(
+            listOf(
+                candidate("unvalidated-dns", validated = false, hasDns = true),
+                candidate("validated-no-dns", validated = true, hasDns = false),
+                candidate("validated-dns", validated = true, hasDns = true),
+            ))
+
+    assertEquals("validated-dns", result)
+  }
+
+  @Test
+  fun prefersValidatedNetworkWithoutDnsOverUnvalidatedNetworkWithDns() {
+    val result =
+        pickPreferredNetwork(
+            listOf(
+                candidate("unvalidated-dns", validated = false, hasDns = true),
+                candidate("validated-no-dns", validated = true, hasDns = false),
+            ))
+
+    assertEquals("validated-no-dns", result)
+  }
+
+  @Test
+  fun fallsBackToUnvalidatedNetworkWithDns() {
+    val result =
+        pickPreferredNetwork(
+            listOf(
+                candidate("unvalidated-no-dns", validated = false, hasDns = false),
+                candidate("unvalidated-dns", validated = false, hasDns = true),
+            ))
+
+    assertEquals("unvalidated-dns", result)
+  }
+
+  @Test
+  fun fallsBackToUnvalidatedNetworkWithoutDns() {
+    val result =
+        pickPreferredNetwork(listOf(candidate("unvalidated", validated = false, hasDns = false)))
+
+    assertEquals("unvalidated", result)
+  }
+
+  @Test
+  fun prefersNonMeteredNetworkWithinSameTier() {
+    val result =
+        pickPreferredNetwork(
+            listOf(
+                candidate("metered", nonMetered = false),
+                candidate("non-metered", nonMetered = true),
+            ))
+
+    assertEquals("non-metered", result)
+  }
+
+  @Test
+  fun ignoresNetworksWithoutInternet() {
+    val result =
+        pickPreferredNetwork(
+            listOf(
+                candidate("no-internet", internet = false),
+                candidate("internet"),
+            ))
+
+    assertEquals("internet", result)
+  }
+
+  @Test
+  fun ignoresVpnNetworks() {
+    val result =
+        pickPreferredNetwork(
+            listOf(
+                candidate("vpn", notVpn = false),
+                candidate("non-vpn"),
+            ))
+
+    assertEquals("non-vpn", result)
+  }
+
+  @Test
+  fun returnsNullWhenNoUsableNetworkExists() {
+    val result =
+        pickPreferredNetwork(
+            listOf(
+                candidate("no-internet", internet = false),
+                candidate("vpn", notVpn = false),
+            ))
+
+    assertNull(result)
+  }
+
+  private fun candidate(
+      name: String,
+      internet: Boolean = true,
+      notVpn: Boolean = true,
+      validated: Boolean = true,
+      hasDns: Boolean = true,
+      nonMetered: Boolean = false,
+  ) =
+      NetworkCandidate(
+          value = name,
+          internet = internet,
+          notVpn = notVpn,
+          validated = validated,
+          hasDns = hasDns,
+          nonMetered = nonMetered,
+      )
+}


### PR DESCRIPTION
This updates the logic for choosing a network to prefer validated networks when possible, where validated networks are confirmed to provide connectivity. We continue to fall back to unvalidated networks when no validated network is available.

This also sets the underlying network, https://developer.android.com/reference/android/net/VpnService#setUnderlyingNetworks(android.net.Network[]) which is required each time the VPN's underlying network changes.

Updates tailscale/corp#47631