### PR TITLE
android: handle empty and duplicate split tunnel allowlist cases

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/IPNService.kt
+++ b/android/src/main/java/com/tailscale/ipn/IPNService.kt
@@ -233,8 +233,8 @@ open class IPNService : VpnService(), libtailscale.IPNService {
             tailscalePackageName = UninitializedApp.get().packageName,
             builtInDisallowedPackages = UninitializedApp.get().builtInDisallowedPackageNames)
 
-    if (allowPackages) {
-      for (packageName in packagesList) {
+    if (allowPackages && packagesList.isNotEmpty()) {
+      for (packageName in (packagesList + tailscalePackageName).distinct()) {
         TSLog.d(TAG, "Including app: $packageName")
         allowApp(b, packageName)
       }

--- a/android/src/test/kotlin/com/tailcale/ipn/IPNServiceTest.kt
+++ b/android/src/test/kotlin/com/tailcale/ipn/IPNServiceTest.kt
@@ -30,4 +30,28 @@ class IPNServiceTest {
 
     assertEquals(listOf("com.example.excluded", "com.example.builtin"), packages)
   }
+
+  @Test
+  fun emptyAllowedPackagesDoesNotAddTailscale() {
+    val packages =
+        packagesForVpnBuilder(
+            packagesList = emptyList(),
+            allowPackages = true,
+            tailscalePackageName = "com.tailscale.ipn",
+            builtInDisallowedPackages = emptyList())
+
+    assertEquals(emptyList<String>(), packages)
+  }
+
+  @Test
+  fun allowedPackagesDeduplicatesTailscale() {
+    val packages =
+        packagesForVpnBuilder(
+            packagesList = listOf("com.termux", "com.tailscale.ipn"),
+            allowPackages = true,
+            tailscalePackageName = "com.tailscale.ipn",
+            builtInDisallowedPackages = emptyList())
+
+    assertEquals(listOf("com.termux", "com.tailscale.ipn"), packages)
+  }
 }


### PR DESCRIPTION
Updates tailscale/tailscale#20978