### PR TITLE
android: update DNS when default network is changed

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/NetworkChangeCallback.kt
+++ b/android/src/main/java/com/tailscale/ipn/NetworkChangeCallback.kt
@@ -105,12 +105,18 @@ object NetworkChangeCallback {
             }
           }
 
-          override fun onCapabilitiesChanged(network: Network, capabilities: NetworkCapabilities) {
+          override fun onCapabilitiesChanged(
+              network: Network,
+              capabilities: NetworkCapabilities,
+          ) {
             super.onCapabilitiesChanged(network, capabilities)
 
             lock.withLock {
               activeNetworks[network]?.caps = capabilities
-              recomputeDefaultNetworkLocked("onCapabilitiesChanged")
+
+              if (recomputeDefaultNetworkLocked("onCapabilitiesChanged")) {
+                maybeUpdateDNSConfig("onCapabilitiesChanged", dns)
+              }
             }
           }
 
@@ -167,10 +173,12 @@ object NetworkChangeCallback {
         })
   }
 
-  // Update cached default network + log interface name.
-  private fun recomputeDefaultNetworkLocked(why: String) {
+  // Update cached default network + log interface name. Return whether or not default network
+  // changed.
+  private fun recomputeDefaultNetworkLocked(why: String): Boolean {
     val oldNetwork = cachedDefaultNetwork
     val newNetwork = pickDefaultNetwork()
+
     cachedDefaultNetwork = newNetwork
 
     val info = if (newNetwork != null) activeNetworks[newNetwork] else null
@@ -178,11 +186,16 @@ object NetworkChangeCallback {
     cachedDefaultInterfaceName = info?.linkProps?.interfaceName
 
     TSLog.d(
-        TAG, "$why: cachedDefaultNetwork=$newNetwork iface=${cachedDefaultInterfaceName ?: "none"}")
+        TAG,
+        "$why: cachedDefaultNetwork=$newNetwork iface=${cachedDefaultInterfaceName ?: "none"}",
+    )
 
     if (newNetwork != oldNetwork) {
       underlyingNetworkListener?.invoke(newNetwork)
+      return true
     }
+
+    return false
   }
 
   // maybeUpdateDNSConfig will maybe update our DNS configuration based on the

--- a/android/src/test/kotlin/com/tailcale/ipn/NetworkChangeCallbackTest.kt
+++ b/android/src/test/kotlin/com/tailcale/ipn/NetworkChangeCallbackTest.kt
@@ -101,6 +101,18 @@ class NetworkChangeCallbackTest {
     assertNull(result)
   }
 
+  @Test
+  fun networkCanBecomePreferredWhenItBecomesValidated() {
+    val cellular = candidate("cellular", validated = true, nonMetered = false)
+    val wifi = candidate("wifi", validated = false, nonMetered = true)
+
+    assertEquals("cellular", pickPreferredNetwork(listOf(cellular, wifi)))
+
+    val validatedWifi = wifi.copy(validated = true)
+
+    assertEquals("wifi", pickPreferredNetwork(listOf(cellular, validatedWifi)))
+  }
+
   private fun candidate(
       name: String,
       internet: Boolean = true,


### PR DESCRIPTION
When a new network is detected, we get onAvailable, onCapabilitiesChanged, onLinkPropertiesChanged, and these trigger recomputing and possible updating of the default network. Only onLinkPropertiesChanged updates the dns config, and if the network validation happens after onLinkPropertiesChanged fires, then the cached default network is still on a different network. This refreshes the dns config when a capabilities change causes the selected network to change.

Updates tailscale/corp#47631