### PR TITLE
android: add diagnostics for duplicate peer keys

### DIFF
--- a/android/src/main/java/com/tailscale/ipn/ui/notifier/Notifier.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/notifier/Notifier.kt
@@ -232,6 +232,43 @@ object Notifier {
       val suffix = next.magicDNSSuffix()
       next = next.copy(Peers = mergePeers(next.Peers, changed.map { it.withDisplayNames(suffix) }))
     }
+
+    val peers = next.Peers.orEmpty()
+    val duplicateStableIDs = peers.groupBy { it.StableID }.filterValues { it.size > 1 }
+    val duplicateNodeIDs = peers.groupBy { it.ID }.filterValues { it.size > 1 }
+    val selfInPeersByStableID = peers.any { it.StableID == next.SelfNode.StableID }
+    val selfInPeersByNodeID = peers.any { it.ID == next.SelfNode.ID }
+
+    check(
+        duplicateStableIDs.isEmpty() &&
+            duplicateNodeIDs.isEmpty() &&
+            !selfInPeersByStableID &&
+            !selfInPeersByNodeID) {
+          buildString {
+            append("Invalid Notifier netmap")
+            append("; sourceInitial=${initial != null}")
+            append("; hadSelfChange=${self != null}")
+            append("; peersChanged=${changed?.size ?: 0}")
+            append("; peersRemoved=${removed?.size ?: 0}")
+            append("; peers=${peers.size}")
+            append("; selfNodeID=${next.SelfNode.ID}")
+            append("; selfStableID=${next.SelfNode.StableID}")
+            append("; duplicateStableIDs=${duplicateStableIDs.keys}")
+            append("; duplicateNodeIDs=${duplicateNodeIDs.keys}")
+            append("; selfInPeersByStableID=$selfInPeersByStableID")
+            append("; selfInPeersByNodeID=$selfInPeersByNodeID")
+            if (duplicateStableIDs.isNotEmpty()) {
+              append("; entries=")
+              append(
+                  duplicateStableIDs.entries.joinToString("|") { (stableID, nodes) ->
+                    "$stableID=[" +
+                        nodes.joinToString(",") { node -> "nodeID=${node.ID}/user=${node.User}" } +
+                        "]"
+                  })
+            }
+          }
+        }
+
     if (next != cur) {
       _netmap.set(next)
     }

--- a/android/src/main/java/com/tailscale/ipn/ui/util/PeerHelper.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/util/PeerHelper.kt
@@ -23,6 +23,38 @@ class PeerCategorizer {
   fun regenerateGroupedPeers(netmap: Netmap.NetworkMap) {
     val peers: List<Tailcfg.Node> = netmap.Peers ?: return
     val selfNode = netmap.SelfNode
+
+    val duplicateStableIDs = peers.groupBy { it.StableID }.filterValues { it.size > 1 }
+    val duplicateNodeIDs = peers.groupBy { it.ID }.filterValues { it.size > 1 }
+    val selfInPeersByStableID = peers.any { it.StableID == selfNode.StableID }
+    val selfInPeersByNodeID = peers.any { it.ID == selfNode.ID }
+
+    check(
+        duplicateStableIDs.isEmpty() &&
+            duplicateNodeIDs.isEmpty() &&
+            !selfInPeersByStableID &&
+            !selfInPeersByNodeID) {
+          buildString {
+            append("Invalid PeerCategorizer input")
+            append("; peers=${peers.size}")
+            append("; selfNodeID=${selfNode.ID}")
+            append("; selfStableID=${selfNode.StableID}")
+            append("; duplicateStableIDs=${duplicateStableIDs.keys}")
+            append("; duplicateNodeIDs=${duplicateNodeIDs.keys}")
+            append("; selfInPeersByStableID=$selfInPeersByStableID")
+            append("; selfInPeersByNodeID=$selfInPeersByNodeID")
+            if (duplicateStableIDs.isNotEmpty()) {
+              append("; entries=")
+              append(
+                  duplicateStableIDs.entries.joinToString("|") { (stableID, nodes) ->
+                    "$stableID=[" +
+                        nodes.joinToString(",") { node -> "nodeID=${node.ID}/user=${node.User}" } +
+                        "]"
+                  })
+            }
+          }
+        }
+
     var grouped = mutableMapOf<UserID, MutableList<Tailcfg.Node>>()
 
     val mdm = MDMSettings.hiddenNetworkDevices.flow.value.value
@@ -33,7 +65,6 @@ class PeerCategorizer {
     val me = netmap.currentUserProfile()
 
     for (peer in (peers + selfNode)) {
-
       val userId = peer.User
       val profile = netmap.userProfile(userId)
 
@@ -128,7 +159,8 @@ class PeerCategorizer {
               }
             }
             .filterNotNull()
-    lastSearchResult = matchingSets
+
+    this.lastSearchResult = matchingSets
     return matchingSets
   }
 }

--- a/android/src/main/java/com/tailscale/ipn/ui/view/ExitNodePicker.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/ExitNodePicker.kt
@@ -56,6 +56,15 @@ fun ExitNodePicker(
       val managedByOrganization by model.managedByOrganization.collectAsState()
       val forcedExitNodeId = MDMSettings.exitNodeID.flow.collectAsState().value.value
 
+      val duplicateExitNodeIDs = tailnetExitNodes.groupBy { it.id }.filterValues { it.size > 1 }
+
+      check(duplicateExitNodeIDs.isEmpty()) {
+        "Duplicate exit node IDs in ExitNodePicker: " +
+            duplicateExitNodeIDs.entries.joinToString("; ") { (id, nodes) ->
+              "$id(count=${nodes.size})"
+            }
+      }
+
       LazyColumn(modifier = Modifier.padding(innerPadding)) {
         item(key = "header") {
           if (forcedExitNodeId != null) {

--- a/android/src/main/java/com/tailscale/ipn/ui/view/MainView.kt
+++ b/android/src/main/java/com/tailscale/ipn/ui/view/MainView.kt
@@ -577,6 +577,51 @@ fun PeerList(
   val localClipboardManager = LocalClipboardManager.current
   // Restrict search to devices running API 33+ (see https://github.com/tailscale/corp/issues/27375)
   val enableSearch = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+
+  val renderedPeers =
+      peerList.flatMap { peerSet -> peerSet.peers.map { peer -> peerSet.userID to peer } }
+  val duplicateRenderedStableIDs =
+      renderedPeers.groupBy { (_, peer) -> peer.StableID }.filterValues { it.size > 1 }
+  val duplicateRenderedNodeIDs =
+      renderedPeers.groupBy { (_, peer) -> peer.ID }.filterValues { it.size > 1 }
+
+  val currentNetmap = netmap.value
+  val netmapPeers = currentNetmap?.Peers.orEmpty()
+  val self = currentNetmap?.SelfNode
+  val duplicateNetmapStableIDs = netmapPeers.groupBy { it.StableID }.filterValues { it.size > 1 }
+  val duplicateNetmapNodeIDs = netmapPeers.groupBy { it.ID }.filterValues { it.size > 1 }
+  val selfInPeersByStableID = self != null && netmapPeers.any { it.StableID == self.StableID }
+  val selfInPeersByNodeID = self != null && netmapPeers.any { it.ID == self.ID }
+
+  check(duplicateRenderedStableIDs.isEmpty()) {
+    buildString {
+      append("Duplicate StableIDs in MainView")
+      append("; peerSets=${peerList.size}")
+      append("; renderedPeers=${renderedPeers.size}")
+      append("; netmapPeers=${netmapPeers.size}")
+      append("; duplicateRenderedStableIDs=${duplicateRenderedStableIDs.keys}")
+      append("; duplicateRenderedNodeIDs=${duplicateRenderedNodeIDs.keys}")
+      append("; duplicateNetmapStableIDs=${duplicateNetmapStableIDs.keys}")
+      append("; duplicateNetmapNodeIDs=${duplicateNetmapNodeIDs.keys}")
+      append("; selfNodeID=${self?.ID}")
+      append("; selfStableID=${self?.StableID}")
+      append("; selfInPeersByNodeID=$selfInPeersByNodeID")
+      append("; selfInPeersByStableID=$selfInPeersByStableID")
+      append("; entries=")
+      append(
+          duplicateRenderedStableIDs.entries.joinToString("|") { (stableID, entries) ->
+            "$stableID=[" +
+                entries.joinToString(",") { (setUser, peer) ->
+                  "nodeID=${peer.ID}" +
+                      "/peerUser=${peer.User}" +
+                      "/setUser=$setUser" +
+                      "/self=${self?.ID == peer.ID}"
+                } +
+                "]"
+          })
+    }
+  }
+
   Column(modifier = Modifier.fillMaxSize()) {
     if (enableSearch && FeatureFlags.isEnabled("enable_new_search")) {
       Search(onSearchBarClick)


### PR DESCRIPTION
Play Store crash reports show Compose failing with duplicate LazyColumn keys, but don't identify the data producing the duplicate. The most likely candidates are peer-related lists since the reports show duplicate keys such as "2", "12", etc., and MainView keys peers directly by StableID and ExitNodePicker keys tailnet exit nodes by ID, while other keyed lists use prefixed or non-numeric keys.

This adds checks around peer data starting from IPN bus through peer categorization and into MainView and ExitNodePickerView so that future crash reports can give us insight into where the duplicate is introduced.

Updates tailscale/corp#48154